### PR TITLE
Updates to nav bar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -93,11 +93,32 @@
           </li>
 
           <li>
-            <a href="{{ theme_variables.external_urls['resources'] }}" target="_blank">Learning Resources</a>
+            <a href="{{ theme_variables.external_urls['tutorials'] }}" target="_blank">Tutorials</a>
           </li>
 
           <li>
-            <a href="{{ theme_variables.external_urls['slack'] }}" target="_blank">Slack Support</a>
+            <a href="{{ theme_variables.external_urls['partners'] }}">Qiskit Partners</a>
+          </li>
+
+          <li>
+            <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
+              <a class="resource-option with-down-orange-arrow">
+                Resources
+              </a>
+              <div class="resources-dropdown-menu">
+                <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['slack'] }}">
+                  <span class="dropdown-title">Slack support</span>
+                  <p></p>
+                </a>
+                <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['textbook'] }}">
+                  <span class="dropdown-title">Qiskit Textbook</span>
+                  <p></p>
+                </a>
+                <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['events'] }}">
+                  <span class="dropdown-title">Qiskit events</span>
+                  <p></p>
+                </a>
+            </div>
           </li>
 
           <li>
@@ -281,7 +302,7 @@
           </li>
 
           <li>
-            <a href="{{ theme_variables.external_urls['resources'] }}" target="_blank">Learning Resources</a>
+            <a href="{{ theme_variables.external_urls['tutorials'] }}" target="_blank">Tutorials</a>
           </li>
 
           <li>

--- a/docs/_templates/theme_variables.jinja
+++ b/docs/_templates/theme_variables.jinja
@@ -1,13 +1,14 @@
 {%- set external_urls = {
   'github': 'https://github.com/Qiskit-Partners/qiskit-ionq',
-  'github_issues': 'https://github.com/Qiskit-Partners/qiskit-ionq/issues',
-  'contributing': 'https://github.com/Qiskit/qiskit/blob/master/CONTRIBUTING.md',
   'docs': 'https://qiskit.org/documentation/',
   'twitter': 'https://twitter.com/qiskit',
+  'events': 'https://qiskit.org/events',
+  'textbook': 'https://qiskit.org/textbook',
   'slack': 'https://qiskit.slack.com',
   'home': 'https://qiskit.org/',
   'started': 'https://qiskit.org/',
-  'resources': 'https://qiskit.org/learn',
+  'partners': 'https://qiskit.org/documentation/partners/',
+  'tutorials': 'https://qiskit.org/documentation/tutorials.html',
   'youtube': 'https://www.youtube.com/qiskit',
 }
 -%}


### PR DESCRIPTION
There was no way to go back to the main Partners docs from the ionq docs.  This fixes that in the main nav bar. 

Also adds tutorials and resources instead of "Learning Resources" to better mirror main docs navigation.