### PR TITLE
fix and test against sumulator output with integers

### DIFF
--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -98,11 +98,12 @@ def _build_counts(result, use_sampler=False, sampler_seed=None):
     if use_sampler:
         rand = np.random.RandomState(sampler_seed)
         outcomes, weights = zip(*output_probs.items())
-        weights = np.array(weights)
-        outcomes = np.array(outcomes)
+        weights = np.array(weights).astype(float)
         # just in case the sum isn't exactly 1 — sometimes the API returns
-        #   e.g. 0.499999 due to floating point error
+        #  e.g. 0.499999 due to floating point error
         weights /= weights.sum()
+        outcomes = np.array(outcomes)
+
         rand_values = rand.choice(outcomes, shots, p=weights)
 
         sampled.update({key: np.count_nonzero(rand_values == key) for key in output_probs})

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -64,11 +64,7 @@ def spy(instance, attr):
         mock.MagicMock: A mock object that will spy on ``attr``.
     """
     actual_attr = getattr(instance, attr)
-    patch = mock.patch.object(
-        instance,
-        attr,
-        wraps=actual_attr,
-    )
+    patch = mock.patch.object(instance, attr, wraps=actual_attr,)
     return patch
 
 
@@ -100,12 +96,7 @@ def test_build_counts():
         "qubits": 3,
         "data": {
             "histogram": {"5": 0.5, "7": 0.5},
-            "registers": {
-                "meas_mapped": {
-                    "3": 0.5,
-                    "7": 0.5,
-                }
-            },
+            "registers": {"meas_mapped": {"3": 0.5, "7": 0.5,}},
         },
         "metadata": {
             "shots": "100",
@@ -156,6 +147,21 @@ def test_counts__simulator_probs(simulator_backend, requests_mock):
     assert {"01": 0.499999, "11": 0.5} == probabilities
 
 
+def test_build_counts__with_int():
+    """Test that a result with an integer doesn't break everything."""
+    result = {
+        "qubits": 1,
+        "data": {"histogram": {"1": 1}, "registers": {"meas_mapped": {"1": 1}},},
+        "metadata": {
+            "shots": "100",
+            "qiskit_header": compress_dict_to_metadata_string({"memory_slots": 3}),
+        },
+    }
+    counts, probabilties = ionq_job._build_counts(result, use_sampler=True, sampler_seed=42)
+    assert ({"0x1": 100}) == counts
+    assert ({"0x1": 1.0}) == probabilties
+
+
 def test_counts_and_probs_from_job(simulator_backend, requests_mock):
     """Test that the helper methods on the job return the same data as the methods on the result"""
     # Dummy job ID for formatted results fixture.
@@ -184,9 +190,7 @@ def test_submit__without_circuit(mock_backend, requests_mock):
     # Mock the initial status call.
     fetch_path = mock_backend.client.make_path("jobs", job_id)
     requests_mock.get(
-        fetch_path,
-        status_code=200,
-        json=conftest.dummy_job_response(job_id),
+        fetch_path, status_code=200, json=conftest.dummy_job_response(job_id),
     )
 
     # Create the job (this calls .status())
@@ -213,9 +217,7 @@ def test_submit(mock_backend, requests_mock):
     # Mock the initial status call.
     fetch_path = mock_backend.client.make_path("jobs")
     requests_mock.post(
-        fetch_path,
-        status_code=200,
-        json=conftest.dummy_job_response("server_job_id"),
+        fetch_path, status_code=200, json=conftest.dummy_job_response("server_job_id"),
     )
 
     # Create a job ref (this does not call status, since circuit is not None).
@@ -240,9 +242,7 @@ def test_cancel(mock_backend, requests_mock):
     client = mock_backend.client
     fetch_path = client.make_path("jobs", job_id)
     requests_mock.get(
-        fetch_path,
-        status_code=200,
-        json=conftest.dummy_job_response(job_id),
+        fetch_path, status_code=200, json=conftest.dummy_job_response(job_id),
     )
 
     # Mock a request to cancel.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary
Because the ionq simulator has some floating point weirdness, we re-normalize the results to make sure that all of the probabilities in the random sampling add up to one.

When there is one output state where p=1 in the simulator output, numpy freaks out when we're normalizing, because 1 is an integer and it's not cool with that.

forcibly casting all of the states to floats beforehand fixes this.