### PR TITLE
Provide support for Amplitude Estimation algorithms and similar

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -290,7 +290,7 @@ def qiskit_to_ionq(circuit_or_qobj, backend_name, passed_args=None):
     """Serialize a Qiskit circuit to a IonQ compatible dict.
 
     Parameters:
-        circuit_or_qobj (:class:`qiskit.circuit.QuantumCircuit` or :class:`qiskit.qobj.QasmQobj`):   
+        circuit_or_qobj (:class:`qiskit.circuit.QuantumCircuit` or :class:`qiskit.qobj.QasmQobj`):
             A Qiskit quantum circuit or qobj containing a circuit in QASM.
         backend_name (str): Backend name.
         passed_args (dict): Dictionary containing additional passed arguments, eg. shots.

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -286,22 +286,23 @@ def decompress_metadata_string_to_dict(input_string):  # pylint: disable=invalid
     return json.loads(decompressed)
 
 
-def qiskit_to_ionq(circuitOrQobj, backend_name, passed_args=None):
+def qiskit_to_ionq(circuit_or_qobj, backend_name, passed_args=None):
     """Serialize a Qiskit circuit to a IonQ compatible dict.
 
     Parameters:
-        circuitOrQobj (:class:`qiskit.circuit.QuantumCircuit` or :class:`qiskit.qobj.QasmQobj`): A Qiskit quantum circuit or qobj containing a circuit in QASM.
+        circuit_or_qobj (:class:`qiskit.circuit.QuantumCircuit` or :class:`qiskit.qobj.QasmQobj`):   
+            A Qiskit quantum circuit or qobj containing a circuit in QASM.
         backend_name (str): Backend name.
         passed_args (dict): Dictionary containing additional passed arguments, eg. shots.
 
     Returns:
         dict: A dict with IonQ API compatible values.
     """
-    circuit = circuitOrQobj
+    circuit = circuit_or_qobj
     # if the submit job method gets passed a Qobj (possible via e.g. the Qiskit.execute method),
     # pull the circuit off the Qobj. We don't need any of the rest of the context it provides.
-    if isinstance(circuitOrQobj, QasmQobj):
-        circuit_list, _, _ = disassemble(circuitOrQobj)
+    if isinstance(circuit_or_qobj, QasmQobj):
+        circuit_list, _, _ = disassemble(circuit_or_qobj)
         circuit = circuit_list.pop()
 
     passed_args = passed_args or {}

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -204,15 +204,6 @@ class IonQBackend(Backend):
 
         return [ionq_job.IonQJob(self, job_id, self.client) for job_id in job_ids]
 
-    # TODO: Implement backend status checks.
-    def status(self):
-        """Not yet implemented.
-
-        Raises:
-            NotImplementedError: This behavior is not currently supported.
-        """
-        raise NotImplementedError("Backend status check is not supported.")
-
     def calibration(self):
         """Fetch the most recent calibration data for this backend.
 

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -191,13 +191,7 @@ class IonQBackend(Backend):
             kwargs["shots"] = self.options.shots
         passed_args = kwargs
 
-        job = ionq_job.IonQJob(
-            self,
-            None,
-            self.client,
-            circuit=circuit,
-            passed_args=passed_args,
-        )
+        job = ionq_job.IonQJob(self, None, self.client, circuit=circuit, passed_args=passed_args,)
         job.submit()
         return job
 
@@ -290,7 +284,7 @@ class IonQSimulatorBackend(IonQBackend):
                 "memory": False,
                 "n_qubits": 29,
                 "conditional": False,
-                "max_shots": 1,
+                "max_shots": None,
                 "max_experiments": 1,
                 "open_pulse": False,
                 "gates": [{"name": "TODO", "parameters": [], "qasm_def": "TODO"}],

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -217,7 +217,7 @@ class IonQJob(JobV1):
         """
         return self.result().get_probabilities()
 
-    def result(self):
+    def result(self, **kwargs):
         """Retrieve job result data.
 
         .. NOTE::

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -239,7 +239,8 @@ class IonQJob(JobV1):
         Returns:
             Result: A Qiskit :class:`Result <qiskit.result.Result>` representation of this job.
         """
-        _ = kwargs  # we ignore all result args like timeout etc, but consume them for compatibility reasons
+        # we ignore all result args like timeout etc, but consume them for compatibility reasons
+        _ = kwargs
 
         # Short-circuit if we have already cached the result for this job.
         if self._result is not None:

--- a/qiskit_ionq/ionq_job.py
+++ b/qiskit_ionq/ionq_job.py
@@ -239,6 +239,8 @@ class IonQJob(JobV1):
         Returns:
             Result: A Qiskit :class:`Result <qiskit.result.Result>` representation of this job.
         """
+        _ = kwargs  # we ignore all result args like timeout etc, but consume them for compatibility reasons
+
         # Short-circuit if we have already cached the result for this job.
         if self._result is not None:
             return self._result

--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -60,12 +60,6 @@ gate_serializations = [
     ("i", [0], []),
     ("id", [0], []),
     ("mcp", [0.5, [0, 1], 2], [{"gate": "z", "rotation": 0.5, "targets": [2], "controls": [0, 1]}]),
-    ("mct", [[0, 1], 2], [{"gate": "x", "targets": [2], "controls": [0, 1]}]),
-    ("mcx", [[0, 1], 2], [{"gate": "x", "targets": [2], "controls": [0, 1]}]),
-    # make sure that multi-control can take any number of controls
-    ("mcx", [[0, 1, 2], 3], [{"gate": "x", "targets": [3], "controls": [0, 1, 2]}]),
-    ("mcx", [[0, 1, 2, 3], 4], [{"gate": "x", "targets": [4], "controls": [0, 1, 2, 3]}]),
-    ("mcx", [[0, 1, 2, 3, 4], 5], [{"gate": "x", "targets": [5], "controls": [0, 1, 2, 3, 4]}]),
     ("measure", [0, 0], []),
     ("p", [0, 0], [{"gate": "z", "rotation": 0, "targets": [0]}]),
     ("p", [0.5, 0], [{"gate": "z", "rotation": 0.5, "targets": [0]}]),

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -29,10 +29,9 @@
 import json
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.compiler import assemble
 
 from qiskit_ionq.helpers import qiskit_to_ionq, decompress_metadata_string_to_dict
-
-from qiskit.compiler import assemble
 
 
 def test_output_map__with_multiple_measurements_to_different_clbits(

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -32,6 +32,8 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 from qiskit_ionq.helpers import qiskit_to_ionq, decompress_metadata_string_to_dict
 
+from qiskit.compiler import assemble
+
 
 def test_output_map__with_multiple_measurements_to_different_clbits(
     simulator_backend,
@@ -151,6 +153,61 @@ def test_full_circuit(simulator_backend):
     qc.measure(0, 1)
     ionq_json = qiskit_to_ionq(
         qc, simulator_backend.name(), passed_args={"shots": 200, "sampler_seed": 42}
+    )
+    expected_metadata_header = {
+        "memory_slots": 2,
+        "global_phase": 0,
+        "n_qubits": 2,
+        "name": "test_name",
+        "creg_sizes": [["c", 2]],
+        "clbit_labels": [["c", 0], ["c", 1]],
+        "qreg_sizes": [["q", 2]],
+        "qubit_labels": [["q", 0], ["q", 1]],
+    }
+    expected_output_map = [1, 0]
+    expected_metadata = {"shots": "200", "sampler_seed": "42"}
+    expected_rest_of_payload = {
+        "lang": "json",
+        "target": "simulator",
+        "shots": 200,
+        "body": {
+            "qubits": 2,
+            "circuit": [
+                {"gate": "x", "controls": [1], "targets": [0]},
+                {"gate": "h", "targets": [1]},
+            ],
+        },
+    }
+
+    actual = json.loads(ionq_json)
+    actual_metadata = actual.pop("metadata") or {}
+    actual_metadata_header = decompress_metadata_string_to_dict(
+        actual_metadata.pop("qiskit_header") or None
+    )
+    actual_maps = actual.pop("registers") or {}
+    actual_output_map = actual_maps.pop("meas_mapped") or []
+
+    # check dict equality:
+    assert actual_metadata == expected_metadata
+    assert actual_metadata_header == expected_metadata_header
+    assert actual_output_map == expected_output_map
+    assert actual == expected_rest_of_payload
+
+
+def test_full_circuit_from_qobj(simulator_backend):
+    """Test a full circuit
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    qc = QuantumCircuit(2, 2, name="test_name")
+    qc.cnot(1, 0)
+    qc.h(1)
+    qc.measure(1, 0)
+    qc.measure(0, 1)
+    qobj = assemble(qc, backend=simulator_backend, shots=200)
+    ionq_json = qiskit_to_ionq(
+        qobj, simulator_backend.name(), passed_args={"shots": 200, "sampler_seed": 42}
     )
     expected_metadata_header = {
         "memory_slots": 2,

--- a/test/ionq_backend/test_base_backend.py
+++ b/test/ionq_backend/test_base_backend.py
@@ -37,19 +37,6 @@ from qiskit_ionq import exceptions, ionq_client, ionq_job
 from .. import conftest
 
 
-def test_status_not_implemented(mock_backend):
-    """Test that by default, `status` is not implemented.
-
-    Args:
-        mock_backend (MockBackend): A fake/mock IonQBackend.
-    """
-
-    with pytest.raises(NotImplementedError) as exc_info:
-        mock_backend.status()
-
-    assert str(exc_info.value) == "Backend status check is not supported."
-
-
 def test_client_property(mock_backend):
     """
     Test that the client property is an IonQClient instance.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary
It seems like some Terra methods still pass Qobj/don't respect versioned backend classes. I know this is an ongoing epic but until it's fully complete, it seems best to support at least a rudimentary qobj case (single QASM experiment in the qobj) in our conversion and serialization helpers so as to allow a broader chunk of Qiskit's prebuilt algorithms to be used. Also intend to open an issue in Terra addressing this, but want to get an interim fix in to address this user need which we know from private conversations is fairly urgent/critical.

Also removes backend "support" for mcx gates until https://github.com/Qiskit/qiskit-terra/issues/6271 is resolved — we need to decompose the Qobj, and we can't do that if mcx gates are present right now. Given we're just transpiling these on the API side right now anyway (i.e. it's not a native gate or somehow magically better decomposition) it's a pretty meaningless change from a UX perspective. 

fixes #65 