### PR TITLE
Bump terra version pin and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The IonQ Provider uses IonQ's REST API, and using the provider requires an API a
 
 ## Installation
 
-> :information_source: **The Qiskit IonQ Provider requires** `qiskit-terra>=0.17.0`!
+> :information_source: **The Qiskit IonQ Provider requires** `qiskit-terra>=0.17.4`!
 >
 > To ensure you are on the latest version, run:
 >
 > ```bash
-> pip install -U "qiskit-terra>=0.17.0"
+> pip install -U "qiskit-terra>=0.17.4"
 > ```
 
 You can install the provider using pip:

--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -3,11 +3,11 @@ Installing the Qiskit IonQ Provider
 
 .. NOTE::
 
-      **The Qiskit IonQ Provider requires** ``qiskit-terra>=0.17.0``!
+      **The Qiskit IonQ Provider requires** ``qiskit-terra>=0.17.4``!
 
       To ensure you are on the latest version, run::
 
-         pip install -U "qiskit-terra>=0.17.0"
+         pip install -U "qiskit-terra>=0.17.4"
 
 
 You can install the provider using pip::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit-terra>=0.17.0
+qiskit-terra>=0.17.4
 requests>=2.24.0


### PR DESCRIPTION
Bump version pin to `qiskit-terra>=0.17.4`, to prevent legacy aqua/framework bugs.

