### PR TITLE
Update circuit helper methods to handle list of size one

### DIFF
--- a/test/helpers/test_gate_serialization.py
+++ b/test/helpers/test_gate_serialization.py
@@ -246,3 +246,27 @@ def test_circuit_with_multiple_registers():
     ]
     built, _, _ = qiskit_circ_to_ionq_circ(qc)
     assert built == expected
+
+
+def test_simple_circuit_wrapped_in_list():
+    """Test basic structure of a simple circuit when wrapped in a list."""
+    qc = QuantumCircuit(1, 1)
+    qc.h(0)
+    qc.measure(0, 0)
+    expected = [{"gate": "h", "targets": [0]}]
+    built, _, _ = qiskit_circ_to_ionq_circ([qc])
+    assert built == expected
+
+
+def test_multi_circuit_list():
+    """
+    Test that `qiskit_circ_to_ionq_circ` raises out if more than one circuit is provided.
+    """
+    qc0 = QuantumCircuit(1, 1)
+    qc0.measure(0, 0)
+    qc1 = QuantumCircuit(1, 1)
+    qc1.x(0)
+    qc1.measure(0, 0)
+    with pytest.raises(RuntimeError) as exc:
+        qiskit_circ_to_ionq_circ([qc0, qc1])
+    assert str(exc.value) == "Multi-experiment jobs are not supported!"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary
Updates the `qiskit_to_ionq` and `qiskit_circ_to_ionq_circ` helper methods to support a single element, or a list of size one, when being invoked.



### Details and comments
This is in accordance with the changes introduced in https://github.com/Qiskit-Partners/qiskit-ionq/pull/71. Support for multi-circuit experiments should probably be added to these methods when https://github.com/Qiskit-Partners/qiskit-ionq/issues/70 is addressed.
