### PR TITLE
Support more backends by doing prefix filtering

### DIFF
--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -141,5 +141,5 @@ class BackendService:
         # pylint: disable=arguments-differ
         backends = self._backends
         if name:
-            backends = [b for b in self._backends if b.name() == name]
+            backends = [b for b in self._backends if name.starts_with(b.name())]
         return filter_backends(backends, filters, **kwargs)

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -141,5 +141,5 @@ class BackendService:
         # pylint: disable=arguments-differ
         backends = self._backends
         if name:
-            backends = [b for b in self._backends if name.starts_with(b.name())]
+            backends = [b for b in self._backends if name.startswith(b.name())]
         return filter_backends(backends, filters, **kwargs)


### PR DESCRIPTION
Ideally, we can dynamically fetch the backends and have the correct qubit count. This does not do that, but simply unblocks use of more specific targets.