### PR TITLE
Version bump prepping release 0.2.0

### DIFF
--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 2, 0, "dev0")])
+VERSION_INFO = ".".join([str(x) for x in (0, 2, 0)])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:


### PR DESCRIPTION
### Summary

Promoting pre-release 0.2.0.dev0 to 0.2.0

### Details and comments

See release notes at https://github.com/Qiskit-Partners/qiskit-ionq/releases/tag/v0.2.0.dev0