### PR TITLE
Pipe target through the qiskit stack, add test

### DIFF
--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -26,6 +26,7 @@
 
 """IonQ provider backends."""
 
+import abc
 import warnings
 
 import dateutil.parser
@@ -252,6 +253,19 @@ class IonQBackend(Backend):
             return None
         return Calibration(calibration_data)
 
+    @abc.abstractmethod
+    def with_target(self, target):
+        """Helper method that returns this backend with a more specific target."""
+        pass
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.name() == other.name()
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class IonQSimulatorBackend(IonQBackend):
     """
@@ -297,11 +311,11 @@ class IonQSimulatorBackend(IonQBackend):
         """
         return None
 
-    def __init__(self, provider):
+    def __init__(self, provider, target=None):
         """Base class for interfacing with an IonQ backend"""
         config = BackendConfiguration.from_dict(
             {
-                "backend_name": "ionq_simulator",
+                "backend_name": target or "ionq_simulator",
                 "backend_version": "0.0.1",
                 "simulator": True,
                 "local": False,
@@ -319,14 +333,18 @@ class IonQSimulatorBackend(IonQBackend):
         )
         super().__init__(configuration=config, provider=provider)
 
+    def with_target(self, target):
+        """Helper method that returns this backend with a more specific target."""
+        return IonQSimulatorBackend(self._provider, target)
 
 class IonQQPUBackend(IonQBackend):
     """IonQ Backend for running qpu-based jobs."""
 
-    def __init__(self, provider):
+    def __init__(self, provider, target=None):
+        self._target = target
         config = BackendConfiguration.from_dict(
             {
-                "backend_name": "ionq_qpu",
+                "backend_name": target or "ionq_qpu",
                 "backend_version": "0.0.1",
                 "simulator": False,
                 "local": False,
@@ -343,6 +361,11 @@ class IonQQPUBackend(IonQBackend):
             }
         )
         super().__init__(configuration=config, provider=provider)
+
+    def with_target(self, target):
+        """Helper method that returns this backend with a more specific target."""
+        return IonQQPUBackend(self._provider, target)
+
 
 
 __all__ = ["IonQBackend", "IonQQPUBackend", "IonQSimulatorBackend"]

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -254,8 +254,8 @@ class IonQBackend(Backend):
         return Calibration(calibration_data)
 
     @abc.abstractmethod
-    def with_target(self, target):
-        """Helper method that returns this backend with a more specific target."""
+    def with_name(self, name):
+        """Helper method that returns this backend with a more specific target system."""
         pass
 
     def __eq__(self, other):
@@ -311,11 +311,11 @@ class IonQSimulatorBackend(IonQBackend):
         """
         return None
 
-    def __init__(self, provider, target=None):
+    def __init__(self, provider, name="ionq_simulator"):
         """Base class for interfacing with an IonQ backend"""
         config = BackendConfiguration.from_dict(
             {
-                "backend_name": target or "ionq_simulator",
+                "backend_name": name,
                 "backend_version": "0.0.1",
                 "simulator": True,
                 "local": False,
@@ -333,18 +333,17 @@ class IonQSimulatorBackend(IonQBackend):
         )
         super().__init__(configuration=config, provider=provider)
 
-    def with_target(self, target):
-        """Helper method that returns this backend with a more specific target."""
-        return IonQSimulatorBackend(self._provider, target)
+    def with_name(self, name):
+        """Helper method that returns this backend with a more specific target system."""
+        return IonQSimulatorBackend(self._provider, name)
 
 class IonQQPUBackend(IonQBackend):
     """IonQ Backend for running qpu-based jobs."""
 
-    def __init__(self, provider, target=None):
-        self._target = target
+    def __init__(self, provider, name="ionq_qpu"):
         config = BackendConfiguration.from_dict(
             {
-                "backend_name": target or "ionq_qpu",
+                "backend_name": name,
                 "backend_version": "0.0.1",
                 "simulator": False,
                 "local": False,
@@ -362,9 +361,9 @@ class IonQQPUBackend(IonQBackend):
         )
         super().__init__(configuration=config, provider=provider)
 
-    def with_target(self, target):
-        """Helper method that returns this backend with a more specific target."""
-        return IonQQPUBackend(self._provider, target)
+    def with_name(self, name):
+        """Helper method that returns this backend with a more specific target system."""
+        return IonQQPUBackend(self._provider, name)
 
 
 

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -99,7 +99,7 @@ class IonQProvider:
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches criteria.")
 
-        return backends[0].with_target(name)
+        return backends[0].with_name(name)
 
 
 class BackendService:

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -99,7 +99,7 @@ class IonQProvider:
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches criteria.")
 
-        return backends[0]
+        return backends[0].with_target(name)
 
 
 class BackendService:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 2, 0)])
+VERSION_INFO = ".".join([str(x) for x in (0, 2, 1)])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,11 +37,10 @@ from qiskit_ionq.helpers import compress_dict_to_metadata_string
 class MockBackend(ionq_backend.IonQBackend):
     """A mock backend for testing super-class behavior in isolation."""
 
-    def __init__(self, provider, target="ionq_mock_backend"):  # pylint: disable=redefined-outer-name
-        self._target = target
+    def __init__(self, provider, name="ionq_mock_backend"):  # pylint: disable=redefined-outer-name
         config = q_models.BackendConfiguration.from_dict(
             {
-                "backend_name": target,
+                "backend_name": name,
                 "backend_version": "0.0.1",
                 "simulator": True,
                 "local": True,
@@ -64,9 +63,9 @@ class MockBackend(ionq_backend.IonQBackend):
         )
         super().__init__(config, provider=provider)
 
-    def with_target(self, target):
-        """Helper method that returns this backend with a more specific target."""
-        return MockBackend(self._provider, target)
+    def with_name(self, name):
+        """Helper method that returns this backend with a more specific target system."""
+        return MockBackend(self._provider, name)
 
 def dummy_job_response(job_id, target="mock_backend", status="completed"):
     """A dummy response payload for `job_id`.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,10 +37,11 @@ from qiskit_ionq.helpers import compress_dict_to_metadata_string
 class MockBackend(ionq_backend.IonQBackend):
     """A mock backend for testing super-class behavior in isolation."""
 
-    def __init__(self, provider):  # pylint: disable=redefined-outer-name
+    def __init__(self, provider, target="ionq_mock_backend"):  # pylint: disable=redefined-outer-name
+        self._target = target
         config = q_models.BackendConfiguration.from_dict(
             {
-                "backend_name": "ionq_mock_backend",
+                "backend_name": target,
                 "backend_version": "0.0.1",
                 "simulator": True,
                 "local": True,
@@ -63,12 +64,16 @@ class MockBackend(ionq_backend.IonQBackend):
         )
         super().__init__(config, provider=provider)
 
+    def with_target(self, target):
+        """Helper method that returns this backend with a more specific target."""
+        return MockBackend(self._provider, target)
 
-def dummy_job_response(job_id, status="completed"):
+def dummy_job_response(job_id, target="mock_backend", status="completed"):
     """A dummy response payload for `job_id`.
 
     Args:
         job_id (str): An arbitrary job id.
+        target (str): Backend target string.
         status (str): A provided status string.
 
     Returns:
@@ -108,7 +113,7 @@ def dummy_job_response(job_id, status="completed"):
                 "meas_mapped": {"1": 0.499999, "3": 0.5}
             },  # implies measurement map of [1,0]
         },
-        "target": "qpu",
+        "target": target,
         "id": job_id,
     }
 
@@ -255,7 +260,7 @@ def formatted_result(provider):
     job_id = "test_id"
 
     # Create a backend and client to use for accessing the job.
-    backend = provider.get_backend("ionq_qpu")
+    backend = provider.get_backend("ionq_qpu.aria.1")
     client = backend.create_client()
 
     # Create the request path for accessing the dummy job:
@@ -264,7 +269,7 @@ def formatted_result(provider):
     # mock a job response
     with _default_requests_mock() as requests_mock:
         # Mock the response with our dummy job response.
-        requests_mock.get(path, json=dummy_job_response(job_id))
+        requests_mock.get(path, json=dummy_job_response(job_id, "qpu.aria.1"))
 
         # Create the job (this calls self.status(), which will fetch the job).
         job = ionq_job.IonQJob(backend, job_id, client)

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -110,7 +110,7 @@ def test_build_counts():
 
 def test_results_meta(formatted_result):
     """Test basic job attribute values."""
-    assert formatted_result.backend_name == "ionq_qpu"
+    assert formatted_result.backend_name.startswith("ionq_qpu")
     assert formatted_result.backend_version == "0.0.1"
     assert formatted_result.qobj_id == "test_qobj_id"
     assert formatted_result.job_id == "test_id"
@@ -413,7 +413,7 @@ def test_result__cancelled(mock_backend, requests_mock):
     """
     # Create the job:
     job_id = "test_id"
-    job_result = conftest.dummy_job_response(job_id, "canceled")
+    job_result = conftest.dummy_job_response(job_id, status="canceled")
     client = mock_backend.client
 
     # Create a job ref (this won't call status, since circuit is not None).

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -41,4 +41,20 @@ def test_provider_getbackend():
     pro = IonQProvider("123456")
 
     for backend in pro.backends():
-        assert backend == pro.get_backend(backend.name())
+        resolved = pro.get_backend(backend.name())
+        assert backend == resolved
+
+
+def test_backend_eq():
+    """Verifies equality works for various backends"""
+    pro = IonQProvider("123456")
+
+    sub1 = pro.get_backend('ionq_qpu.sub.1')
+    sub2 = pro.get_backend('ionq_qpu.sub.2')
+    also_sub1 = pro.get_backend('ionq_qpu.sub.1')
+    simulator = pro.get_backend('ionq_simulator')
+
+    assert sub1 == also_sub1
+    assert sub1 != sub2
+    assert also_sub1 != sub2
+    assert sub1 != simulator


### PR DESCRIPTION
### Summary

This fixes a bug in the behavior for 0.2.0, which accepted more specific backend names, but did not pass them server-side

### Details and comments

Planning to release as 0.2.1 if there are no objections.