### PR TITLE
Change overriden method in IonQGateError to __repr__

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -130,7 +130,7 @@ class IonQGateError(IonQError, JobError):
         self.gate_name = gate_name
         super().__init__(
             (f"gate '{gate_name}' not supported on IonQ backends. "
-             + "Please use the qiskit.transpile method or manually rewrite to remove the gate"
+              "Please use the qiskit.transpile method or manually rewrite to remove the gate"
             )
         )
 

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -133,7 +133,7 @@ class IonQGateError(IonQError, JobError):
             "Please use the qiskit.transpile method or manually rewrite to remove the gate"
         )
 
-    def __str__(self):
+    def __repr__(self):
         return f"{self.__class__.__name__}(gate_name={self.gate_name!r})"
 
 

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -129,8 +129,9 @@ class IonQGateError(IonQError, JobError):
     def __init__(self, gate_name):
         self.gate_name = gate_name
         super().__init__(
-            f"gate '{gate_name}' not supported on IonQ backends. "
-            "Please use the qiskit.transpile method or manually rewrite to remove the gate"
+            (f"gate '{gate_name}' not supported on IonQ backends. "
+             + "Please use the qiskit.transpile method or manually rewrite to remove the gate"
+            )
         )
 
     def __repr__(self):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -44,17 +44,20 @@ def test_base_str_and_repr():
 def test_gate_error():
     """Test that IonQAPIError has specific instance attributes."""
     err = exceptions.IonQGateError("a gate")
-    expected = "gate 'a gate' not supported on IonQ backends. " \
-               "Please use the qiskit.transpile method or manually rewrite to remove the gate"
+    expected = ("gate 'a gate' not supported on IonQ backends. "
+                "Please use the qiskit.transpile method or manually rewrite to remove the gate")
     assert err.message == expected
 
 
 def test_gate_error_str_and_repr():
     """Test that IonQAPIError has a str/repr that includes args."""
     err = exceptions.IonQGateError("a gate")
-    expected = "IonQGateError(gate_name='a gate')"
-    assert str(err) == expected
-    assert repr(err) == repr(expected)
+    str_expected = ('IonQGateError("gate \'a gate\' not supported on IonQ backends. '
+                   'Please use the qiskit.transpile method or manually rewrite to remove the gate")'
+                   )
+    repr_expected = "IonQGateError(gate_name='a gate')"
+    assert str(err) == str_expected
+    assert repr(err) == repr_expected
 
 
 def test_api_error():


### PR DESCRIPTION
This was overriding the message defined in the class, so that users would see
IonQGateError(gate_name='foo')
instead of
IonQGateError('gate 'foo' not supported on IonQ backends. Please use the qiskit.transpile method or manually rewrite to remove the gate')

This way, developers will see the former and users the latter, as was originally intended.

