### PR TITLE
Raise n_qubits to max IonQ provides across all QPU backends

### DIFF
--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -351,7 +351,9 @@ class IonQQPUBackend(IonQBackend):
                 "description": "IonQ QPU",
                 "basis_gates": ionq_basis_gates,
                 "memory": False,
-                "n_qubits": 11,
+                # This is a generic backend for all IonQ hardware, the server will do more specific qubit count checks.
+                # In the future, dynamic backend configuration from the server will be used in place of these hard-coded caps.
+                "n_qubits": 23,
                 "conditional": False,
                 "max_shots": 10000,
                 "max_experiments": 1,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -351,8 +351,9 @@ class IonQQPUBackend(IonQBackend):
                 "description": "IonQ QPU",
                 "basis_gates": ionq_basis_gates,
                 "memory": False,
-                # This is a generic backend for all IonQ hardware, the server will do more specific qubit count checks.
-                # In the future, dynamic backend configuration from the server will be used in place of these hard-coded caps.
+                # This is a generic backend for all IonQ hardware, the server will do more specific qubit count 
+                # checks. In the future, dynamic backend configuration from the server will be used in place of
+                # these hard-coded caps.
                 "n_qubits": 23,
                 "conditional": False,
                 "max_shots": 10000,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -351,9 +351,9 @@ class IonQQPUBackend(IonQBackend):
                 "description": "IonQ QPU",
                 "basis_gates": ionq_basis_gates,
                 "memory": False,
-                # This is a generic backend for all IonQ hardware, the server will do more specific qubit count 
-                # checks. In the future, dynamic backend configuration from the server will be used in place of
-                # these hard-coded caps.
+                # This is a generic backend for all IonQ hardware, the server will do more specific
+                # qubit count checks. In the future, dynamic backend configuration from the server
+                # will be used in place of these hard-coded caps.
                 "n_qubits": 23,
                 "conditional": False,
                 "max_shots": 10000,

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 2, 1)])
+VERSION_INFO = ".".join([str(x) for x in (0, 2, 1, "dev0")])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:


### PR DESCRIPTION
If a particular circuit is run on hardware that does not support that specific size, it will be rejected server-side.

This is a bit of a cludge around dynamic backend fetching, once that is completed, we shouldn't be dependent on these SDK-specific caps.