### PR TITLE
Add gate definitions and language selection for Native Gates

### DIFF
--- a/qiskit_ionq/__init__.py
+++ b/qiskit_ionq/__init__.py
@@ -28,3 +28,4 @@
 
 from .ionq_provider import IonQProvider
 from .version import __version__
+from .ionq_gates import GPIGate, GPI2Gate, MSGate

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -126,16 +126,18 @@ class IonQGateError(IonQError, JobError):
         gate_name: The name of the gate which caused this error.
     """
 
-    def __init__(self, gate_name):
+    def __init__(self, gate_name, lang):
         self.gate_name = gate_name
+        self.lang = lang
         super().__init__(
-            (f"gate '{gate_name}' not supported on IonQ backends. "
-              "Please use the qiskit.transpile method or manually rewrite to remove the gate"
+            (f"gate '{gate_name}' is not supported on the '{lang}' IonQ backends. "
+              "Please use the qiskit.transpile method, manually rewrite to remove the gate, "
+              "or change the language selection as appropriate."
             )
         )
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(gate_name={self.gate_name!r})"
+        return f"{self.__class__.__name__}(gate_name={self.gate_name!r}, lang={self.lang!r})"
 
 
 class IonQMidCircuitMeasurementError(IonQError, JobError):

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -126,18 +126,18 @@ class IonQGateError(IonQError, JobError):
         gate_name: The name of the gate which caused this error.
     """
 
-    def __init__(self, gate_name, lang):
+    def __init__(self, gate_name, gateset):
         self.gate_name = gate_name
-        self.lang = lang
+        self.gateset = gateset
         super().__init__(
-            (f"gate '{gate_name}' is not supported on the '{lang}' IonQ backends. "
+            (f"gate '{gate_name}' is not supported on the '{gateset}' IonQ backends. "
               "Please use the qiskit.transpile method, manually rewrite to remove the gate, "
-              "or change the language selection as appropriate."
+              "or change the gateset selection as appropriate."
             )
         )
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(gate_name={self.gate_name!r}, lang={self.lang!r})"
+        return f"{self.__class__.__name__}(gate_name={self.gate_name!r}, gateset={self.gateset!r})"
 
 
 class IonQMidCircuitMeasurementError(IonQError, JobError):

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -132,7 +132,8 @@ def qiskit_circ_to_ionq_circ(input_circuit, lang="qis"):
     Parameters:
         input_circuit (:class:`QuantumCircuit <qiskit.circuit.QuantumCircuit>`): A quantum circuit.
         lang (string): The language to use, can be QIS (required transpilation pass in IonQ
-          backend) or native (optional Qiskit transpilation pass).
+          backend, which is sent standard gates) or native (only IonQ native gates are allowed,
+          in the future we may provide transpilation to these gates in Qiskit).
 
     Raises:
         IonQGateError: If an unsupported instruction is supplied.
@@ -335,8 +336,8 @@ def qiskit_to_ionq(circuit, backend_name, lang="qis", passed_args=None):
     Parameters:
         circuit (:class:`qiskit.circuit.QuantumCircuit`): A Qiskit quantum circuit.
         backend_name (str): Backend name.
-        lang (str): Language, controls which gates are valid (only native operations
-          or QIS, which transpiles in the IonQ backend).
+        lang (str): Language, controls which gates are valid (`native` operations
+          or `qis`, which transpiles in the IonQ backend from standard Qiskit gates).
         passed_args (dict): Dictionary containing additional passed arguments, eg. shots.
 
     Returns:

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -130,7 +130,7 @@ def qiskit_circ_to_ionq_circ(input_circuit, lang="qis"):
        * ``barrier``
 
     Parameters:
-        input_circuit (:class:`QuantumCircuit <qiskit.circuit.QuantumCircuit>`): A quantum circuit.
+        input_circuit (:class:`qiskit.circuit.QuantumCircuit`): A Qiskit quantum circuit.
         lang (string): The language to use, can be QIS (required transpilation pass in IonQ
           backend, which is sent standard gates) or native (only IonQ native gates are allowed,
           in the future we may provide transpilation to these gates in Qiskit).

--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -111,9 +111,9 @@ multi_target_uncontrolled_gates = (
 
 # https://ionq.com/best-practices
 ionq_native_basis_gates = [
-    "gpi",  # All single qubit gates turn into GPI/GPI2
+    "gpi",  # TODO All single qubit gates can transpile into GPI/GPI2
     "gpi2",
-    "ms",  # Global MS gate
+    "ms",  # Pairwise MS gate
 ]
 
 # Each language corresponds to a different set of basis gates.

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -36,7 +36,7 @@ from qiskit.providers.models.backendstatus import BackendStatus
 from qiskit.providers import Options
 
 from . import exceptions, ionq_client, ionq_job
-from .helpers import GATESET_LANG_MAP
+from .helpers import GATESET_MAP
 
 
 class Calibration:
@@ -263,13 +263,13 @@ class IonQBackend(Backend):
         pass
 
     @abc.abstractmethod
-    def lang(self):
-        """Helper method returning the language this backend is targeting."""
+    def gateset(self):
+        """Helper method returning the gateset this backend is targeting."""
         pass
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return self.name() == other.name() and self.lang() == other.lang()
+            return self.name() == other.name() and self.gateset() == other.gateset()
         else:
             return False
 
@@ -321,12 +321,12 @@ class IonQSimulatorBackend(IonQBackend):
         """
         return None
 
-    def lang(self):
-        return self._lang
+    def gateset(self):
+        return self._gateset
 
-    def __init__(self, provider, name="ionq_simulator", lang="qis"):
+    def __init__(self, provider, name="ionq_simulator", gateset="qis"):
         """Base class for interfacing with an IonQ backend"""
-        self._lang = lang
+        self._gateset = gateset
         config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -335,7 +335,7 @@ class IonQSimulatorBackend(IonQBackend):
                 "local": False,
                 "coupling_map": None,
                 "description": "IonQ simulator",
-                "basis_gates": GATESET_LANG_MAP[lang],
+                "basis_gates": GATESET_MAP[gateset],
                 "memory": False,
                 "n_qubits": 29,
                 "conditional": False,
@@ -355,11 +355,11 @@ class IonQSimulatorBackend(IonQBackend):
 class IonQQPUBackend(IonQBackend):
     """IonQ Backend for running qpu-based jobs."""
 
-    def lang(self):
-        return self._lang
+    def gateset(self):
+        return self._gateset
 
-    def __init__(self, provider, name="ionq_qpu", lang="qis"):
-        self._lang = lang
+    def __init__(self, provider, name="ionq_qpu", gateset="qis"):
+        self._gateset = gateset
         config = BackendConfiguration.from_dict(
             {
                 "backend_name": name,
@@ -368,7 +368,7 @@ class IonQQPUBackend(IonQBackend):
                 "local": False,
                 "coupling_map": None,
                 "description": "IonQ QPU",
-                "basis_gates": GATESET_LANG_MAP[lang],
+                "basis_gates": GATESET_MAP[gateset],
                 "memory": False,
                 # This is a generic backend for all IonQ hardware, the server will do more specific
                 # qubit count checks. In the future, dynamic backend configuration from the server

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -81,7 +81,9 @@ class IonQClient:
         Returns:
             dict: A :mod:`requests <requests>` response :meth:`json <requests.Response.json>` dict.
         """
-        as_json = qiskit_to_ionq(job.circuit, job.backend().name(), job._passed_args)
+        as_json = qiskit_to_ionq(
+            job.circuit, job.backend().name(), job.backend().lang(), job._passed_args
+        )
         req_path = self.make_path("jobs")
         res = requests.post(req_path, data=as_json, headers=self.api_headers)
         if res.status_code != 200:

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -82,7 +82,7 @@ class IonQClient:
             dict: A :mod:`requests <requests>` response :meth:`json <requests.Response.json>` dict.
         """
         as_json = qiskit_to_ionq(
-            job.circuit, job.backend().name(), job.backend().lang(), job._passed_args
+            job.circuit, job.backend().name(), job.backend().gateset(), job._passed_args
         )
         req_path = self.make_path("jobs")
         res = requests.post(req_path, data=as_json, headers=self.api_headers)

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -58,7 +58,7 @@ class GPIGate(Gate):
         r"""Return inverted GPI gate.
         :math:`GPI(\lambda){\phi} = GPI(\phi)`
         """
-        return GPIGate(self.params[0])
+        return self
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI gate."""
@@ -89,15 +89,15 @@ class GPI2Gate(Gate):
 
     def inverse(self):
         r"""Return inverted GPI2 gate.
-        :math:`GPI2(\lambda){\phi} = GPI2(-\phi)`
+        :math:`GPI2(\lambda){\phi} = GPI2(\phi + \pi)`
         """
-        return GPI2Gate(-self.params[0])
+        return GPI2Gate(self.params[0] + math.pi)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI gate."""
-        top = -1j * cmath.exp(-self.params[0] * 1j)
+        top = -1j * cmath.exp(self.params[0] * -1j)
         bot = -1j * cmath.exp(self.params[0] * 1j)
-        return numpy.array([[1, top], [bot, 1]], dtype=dtype)
+        return numpy.array([[1, top], [bot, 1]], dtype=dtype)/math.sqrt(2)
 
 
 class MSGate(Gate):
@@ -142,6 +142,13 @@ class MSGate(Gate):
         diag = math.cos(tee)
         adiag = -1j*math.sin(tee)
         return numpy.array(
-            [[diag, 0, 0, -adiag], [0, diag, adiag, 0], [0, adiag, diag, 0], [adiag, 0, 0, diag]],
+            [[diag, 0, 0, adiag], [0, diag, adiag, 0], [0, adiag, diag, 0], [adiag, 0, 0, diag]],
             dtype=dtype,
         )
+
+    def inverse(self):
+        r"""Return inverted MS gate.
+        :math:`MS(\lambda){\phi_0, \phi_1} = MS(\phi_1, \phi_0)`
+        """
+        return MSGate(self.params[1], self.params[0])
+

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -85,7 +85,7 @@ class GPI2Gate(Gate):
         """Return a numpy.array for the GPI2 gate."""
         top = -1j * cmath.exp(self.params[0] * -1j)
         bot = -1j * cmath.exp(self.params[0] * 1j)
-        return numpy.array([[1, top], [bot, 1]], dtype=dtype)/math.sqrt(2)
+        return numpy.array([[1, top], [bot, 1]], dtype=dtype) / math.sqrt(2)
 
 
 class MSGate(Gate):
@@ -126,8 +126,13 @@ class MSGate(Gate):
         """Return a numpy.array for the MS gate."""
         phi0 = self.params[0]
         phi1 = self.params[1]
-        diag = 1/math.sqrt(2)
+        diag = 1 / math.sqrt(2)
         return numpy.array(
-            [[diag, 0, 0, diag*-1j*cmath.exp(-1j*(phi0+phi1))], [0, diag, diag*-1j*cmath.exp(-1j*(phi0-phi1)), 0], [0, diag*-1j*cmath.exp(1j*(phi0-phi1)), diag, 0], [diag*-1j*cmath.exp(1j*(phi0+phi1)), 0, 0, diag]],
+            [
+                [diag, 0, 0, diag * -1j * cmath.exp(-1j * (phi0 + phi1))],
+                [0, diag, diag * -1j * cmath.exp(-1j * (phi0 - phi1)), 0],
+                [0, diag * -1j * cmath.exp(1j * (phi0 - phi1)), diag, 0],
+                [diag * -1j * cmath.exp(1j * (phi0 + phi1)), 0, 0, diag],
+            ],
             dtype=dtype,
         )

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -101,10 +101,10 @@ class MSGate(Gate):
     .. math::
         MS(\phi_0, _\phi_1) q_0, q_1 =
             \frac{1}{\sqrt{2}}\begin{pmatrix}
-                1 & 0         & 0 & -i*e^(-i*(\phi_0+\phi_1) \\
-                0 & 1 & -i*e^(-i*(\phi_0-\phi_1) & 0 \\
-                0 & -i*e^(i*(\phi_0-\phi_1) & 1 & 0 \\
-                -i*e^(i*(\phi_0+\phi_1) & 0 & 0 & 1
+                1 & 0         & 0 & -i*e^{-i*(\phi_0+\phi_1} \\
+                0 & 1 & -i*e^{-i*(\phi_0-\phi_1} & 0 \\
+                0 & -i*e^(i*{\phi_0-\phi_1} & 1 & 0 \\
+                -i*e^(i*{\phi_0+\phi_1} & 0 & 0 & 1
             \end{pmatrix}
     """
 

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -100,13 +100,11 @@ class MSGate(Gate):
     **Matrix representation:**
     .. math::
         MS(\phi_0, _\phi_1) q_0, q_1 =
-            MS(\phi_1 - \phi_0) =
-            MS(t) =
             \frac{1}{\sqrt{2}}\begin{pmatrix}
-                \cos(t) & 0         & 0 & -i*\sin(t) \\
-                0 & \cos(t) & -i*\sin(t) & 0 \\
-                0 & -i*\sin(t) & \cos(t) & 0 \\
-                -i*\sin(t) & 0 & 0 & \cos(t)
+                1 & 0         & 0 & -i*e^(-i*(\phi_0+\phi_1) \\
+                0 & 1 & -i*e^(-i*(\phi_0-\phi_1) & 0 \\
+                0 & -i*e^(i*(\phi_0-\phi_1) & 1 & 0 \\
+                -i*e^(i*(\phi_0+\phi_1) & 0 & 0 & 1
             \end{pmatrix}
     """
 
@@ -126,10 +124,10 @@ class MSGate(Gate):
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the MS gate."""
-        tee = self.params[1] - self.params[0]
-        diag = math.cos(tee)
-        adiag = -1j*math.sin(tee)
+        phi0 = self.params[0]
+        phi1 = self.params[1]
+        diag = 1/math.sqrt(2)
         return numpy.array(
-            [[diag, 0, 0, adiag], [0, diag, adiag, 0], [0, adiag, diag, 0], [adiag, 0, 0, diag]],
+            [[diag, 0, 0, diag*-1j*cmath.exp(-1j*(phi0+phi1))], [0, diag, diag*-1j*cmath.exp(-1j*(phi0-phi1)), 0], [0, diag*-1j*cmath.exp(1j*(phi0-phi1)), diag, 0], [diag*-1j*cmath.exp(1j*(phi0+phi1)), 0, 0, diag]],
             dtype=dtype,
         )

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -54,12 +54,6 @@ class GPIGate(Gate):
         """Create new GPI gate."""
         super().__init__("gpi", 1, [phi], label=label)
 
-    def inverse(self):
-        r"""Return inverted GPI gate.
-        :math:`GPI(\lambda){\phi} = GPI(\phi)`
-        """
-        return self
-
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI gate."""
         top = cmath.exp(self.params[0] * 1j)
@@ -86,12 +80,6 @@ class GPI2Gate(Gate):
     def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
         """Create new GPI2 gate."""
         super().__init__("gpi2", 1, [phi], label=label)
-
-    def inverse(self):
-        r"""Return inverted GPI2 gate.
-        :math:`GPI2(\lambda){\phi} = GPI2(\phi + \pi)`
-        """
-        return GPI2Gate(self.params[0] + math.pi)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI2 gate."""
@@ -145,9 +133,3 @@ class MSGate(Gate):
             [[diag, 0, 0, adiag], [0, diag, adiag, 0], [0, adiag, diag, 0], [adiag, 0, 0, diag]],
             dtype=dtype,
         )
-
-    def inverse(self):
-        r"""Return inverted MS gate.
-        :math:`MS(\lambda){\phi_0, \phi_1} = MS(\phi_1, \phi_0)`
-        """
-        return MSGate(self.params[1], self.params[0])

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -101,10 +101,10 @@ class MSGate(Gate):
     .. math::
         MS(\phi_0, _\phi_1) q_0, q_1 =
             \frac{1}{\sqrt{2}}\begin{pmatrix}
-                1 & 0         & 0 & -i*e^{-i*(\phi_0+\phi_1} \\
-                0 & 1 & -i*e^{-i*(\phi_0-\phi_1} & 0 \\
-                0 & -i*e^(i*{\phi_0-\phi_1} & 1 & 0 \\
-                -i*e^(i*{\phi_0+\phi_1} & 0 & 0 & 1
+                1 & 0         & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1} \\
+                0 & 1 & -i*e^{-i*2*\pi(\phi_0-\phi_1} & 0 \\
+                0 & -i*e^(i*2*\pi{\phi_0-\phi_1} & 1 & 0 \\
+                -i*e^(i*2*\pi{\phi_0+\phi_1} & 0 & 0 & 1
             \end{pmatrix}
     """
 
@@ -129,10 +129,10 @@ class MSGate(Gate):
         diag = 1 / math.sqrt(2)
         return numpy.array(
             [
-                [diag, 0, 0, diag * -1j * cmath.exp(-1j * (phi0 + phi1))],
-                [0, diag, diag * -1j * cmath.exp(-1j * (phi0 - phi1)), 0],
-                [0, diag * -1j * cmath.exp(1j * (phi0 - phi1)), diag, 0],
-                [diag * -1j * cmath.exp(1j * (phi0 + phi1)), 0, 0, diag],
+                [diag, 0, 0, diag * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 + phi1))],
+                [0, diag, diag * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 - phi1)), 0],
+                [0, diag * -1j * cmath.exp(1j * 2 * math.pi * (phi0 - phi1)), diag, 0],
+                [diag * -1j * cmath.exp(1j * 2 * math.pi * (phi0 + phi1)), 0, 0, diag],
             ],
             dtype=dtype,
         )

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -94,7 +94,7 @@ class GPI2Gate(Gate):
         return GPI2Gate(self.params[0] + math.pi)
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the GPI gate."""
+        """Return a numpy.array for the GPI2 gate."""
         top = -1j * cmath.exp(self.params[0] * -1j)
         bot = -1j * cmath.exp(self.params[0] * 1j)
         return numpy.array([[1, top], [bot, 1]], dtype=dtype)/math.sqrt(2)

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -151,4 +151,3 @@ class MSGate(Gate):
         :math:`MS(\lambda){\phi_0, \phi_1} = MS(\phi_1, \phi_0)`
         """
         return MSGate(self.params[1], self.params[0])
-

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -45,8 +45,8 @@ class GPIGate(Gate):
     .. math::
         GPI(\phi) =
             \begin{pmatrix}
-                0 & e^{-i\phi} \\
-                e^{-i\phi} & 0
+                0 & e^{-i*2*\pi*\phi} \\
+                e^{-i*2*\pi*\phi} & 0
             \end{pmatrix}
     """
 
@@ -56,8 +56,8 @@ class GPIGate(Gate):
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI gate."""
-        top = cmath.exp(self.params[0] * 1j)
-        bot = cmath.exp(-self.params[0] * 1j)
+        top = cmath.exp(self.params[0] * 2 * math.pi * 1j)
+        bot = cmath.exp(-self.params[0] * 2 * math.pi * 1j)
         return numpy.array([[0, top], [bot, 0]], dtype=dtype)
 
 
@@ -72,8 +72,8 @@ class GPI2Gate(Gate):
     .. math::
         GPI2(\phi) =
             \begin{pmatrix}
-                1 & -i*e^{-i\phi} \\
-                -i*e^{i\phi} & 1
+                1 & -i*e^{-i*2*\pi*\phi} \\
+                -i*e^{i*2*\pi*\phi} & 1
             \end{pmatrix}
     """
 
@@ -83,8 +83,8 @@ class GPI2Gate(Gate):
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the GPI2 gate."""
-        top = -1j * cmath.exp(self.params[0] * -1j)
-        bot = -1j * cmath.exp(self.params[0] * 1j)
+        top = -1j * cmath.exp(self.params[0] * 2 * math.pi * -1j)
+        bot = -1j * cmath.exp(self.params[0] * 2 * math.pi * 1j)
         return numpy.array([[1, top], [bot, 1]], dtype=dtype) / math.sqrt(2)
 
 
@@ -101,10 +101,10 @@ class MSGate(Gate):
     .. math::
         MS(\phi_0, _\phi_1) q_0, q_1 =
             \frac{1}{\sqrt{2}}\begin{pmatrix}
-                1 & 0         & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1} \\
-                0 & 1 & -i*e^{-i*2*\pi(\phi_0-\phi_1} & 0 \\
-                0 & -i*e^(i*2*\pi{\phi_0-\phi_1} & 1 & 0 \\
-                -i*e^(i*2*\pi{\phi_0+\phi_1} & 0 & 0 & 1
+                1 & 0         & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)} \\
+                0 & 1 & -i*e^{-i*2*\pi(\phi_0-\phi_1)} & 0 \\
+                0 & -i*e^{i*2*\pi(\phi_0-\phi_1)} & 1 & 0 \\
+                -i*e^{i*2*\pi(\phi_0+\phi_1)} & 0 & 0 & 1
             \end{pmatrix}
     """
 

--- a/qiskit_ionq/ionq_gates.py
+++ b/qiskit_ionq/ionq_gates.py
@@ -1,0 +1,147 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2021 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native gateset for IonQ hardware."""
+
+from typing import Optional
+import cmath
+import math
+import numpy
+from qiskit.circuit.gate import Gate
+from qiskit.circuit.parameterexpression import ParameterValueType
+
+
+class GPIGate(Gate):
+    r"""Single-qubit GPI gate.
+    **Circuit symbol:**
+    .. parsed-literal::
+             ┌───────┐
+        q_0: ┤ GPI(ϴ)├
+             └───────┘
+    **Matrix Representation:**
+    .. math::
+        GPI(\phi) =
+            \begin{pmatrix}
+                0 & e^{-i\phi} \\
+                e^{-i\phi} & 0
+            \end{pmatrix}
+    """
+
+    def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
+        """Create new GPI gate."""
+        super().__init__("gpi", 1, [phi], label=label)
+
+    def inverse(self):
+        r"""Return inverted GPI gate.
+        :math:`GPI(\lambda){\phi} = GPI(\phi)`
+        """
+        return GPIGate(self.params[0])
+
+    def __array__(self, dtype=None):
+        """Return a numpy.array for the GPI gate."""
+        top = cmath.exp(self.params[0] * 1j)
+        bot = cmath.exp(-self.params[0] * 1j)
+        return numpy.array([[0, top], [bot, 0]], dtype=dtype)
+
+
+class GPI2Gate(Gate):
+    r"""Single-qubit GPI2 gate.
+    **Circuit symbol:**
+    .. parsed-literal::
+             ┌───────┐
+        q_0: ┤GPI2(ϴ)├
+             └───────┘
+    **Matrix Representation:**
+    .. math::
+        GPI2(\phi) =
+            \begin{pmatrix}
+                1 & -i*e^{-i\phi} \\
+                -i*e^{i\phi} & 1
+            \end{pmatrix}
+    """
+
+    def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
+        """Create new GPI2 gate."""
+        super().__init__("gpi2", 1, [phi], label=label)
+
+    def inverse(self):
+        r"""Return inverted GPI2 gate.
+        :math:`GPI2(\lambda){\phi} = GPI2(-\phi)`
+        """
+        return GPI2Gate(-self.params[0])
+
+    def __array__(self, dtype=None):
+        """Return a numpy.array for the GPI gate."""
+        top = -1j * cmath.exp(-self.params[0] * 1j)
+        bot = -1j * cmath.exp(self.params[0] * 1j)
+        return numpy.array([[1, top], [bot, 1]], dtype=dtype)
+
+
+class MSGate(Gate):
+    r"""Entangling 2-Qubit MS gate.
+    **Circuit symbol:**
+    .. parsed-literal::
+              _______
+        q_0: ┤       ├-
+             |MS(ϴ,0)|
+        q_1: ┤       ├-
+             └───────┘
+    **Matrix representation:**
+    .. math::
+        MS(\phi_0, _\phi_1) q_0, q_1 =
+            MS(\phi_1 - \phi_0) =
+            MS(t) =
+            \frac{1}{\sqrt{2}}\begin{pmatrix}
+                \cos(t) & 0         & 0 & -i*\sin(t) \\
+                0 & \cos(t) & -i*\sin(t) & 0 \\
+                0 & -i*\sin(t) & \cos(t) & 0 \\
+                -i*\sin(t) & 0 & 0 & \cos(t)
+            \end{pmatrix}
+    """
+
+    def __init__(
+        self,
+        phi0: ParameterValueType,
+        phi1: ParameterValueType,
+        label: Optional[str] = None,
+    ):
+        """Create new MS gate."""
+        super().__init__(
+            "ms",
+            2,
+            [phi0, phi1],
+            label=label,
+        )
+
+    def __array__(self, dtype=None):
+        """Return a numpy.array for the MS gate."""
+        tee = self.params[1] - self.params[0]
+        diag = math.cos(tee)
+        adiag = -1j*math.sin(tee)
+        return numpy.array(
+            [[diag, 0, 0, -adiag], [0, diag, adiag, 0], [0, adiag, diag, 0], [adiag, 0, 0, diag]],
+            dtype=dtype,
+        )

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -82,11 +82,11 @@ class IonQProvider:
             ]
         )
 
-    def get_backend(self, name=None, lang="qis", **kwargs):
+    def get_backend(self, name=None, gateset="qis", **kwargs):
         """Return a single backend matching the specified filtering.
         Args:
             name (str): name of the backend.
-            lang (str): language used (QIS or native), defaults to QIS.
+            gateset (str): language used (QIS or native), defaults to QIS.
             **kwargs: dict used for filtering.
         Returns:
             Backend: a backend matching the filtering.
@@ -100,7 +100,7 @@ class IonQProvider:
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches criteria.")
 
-        return backends[0].with_name(name, lang=lang)
+        return backends[0].with_name(name, gateset=gateset)
 
 
 class BackendService:

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -82,10 +82,11 @@ class IonQProvider:
             ]
         )
 
-    def get_backend(self, name=None, **kwargs):
+    def get_backend(self, name=None, lang="qis", **kwargs):
         """Return a single backend matching the specified filtering.
         Args:
             name (str): name of the backend.
+            lang (str): language used (QIS or native), defaults to QIS.
             **kwargs: dict used for filtering.
         Returns:
             Backend: a backend matching the filtering.
@@ -99,7 +100,7 @@ class IonQProvider:
         if not backends:
             raise QiskitBackendNotFoundError("No backend matches criteria.")
 
-        return backends[0].with_name(name)
+        return backends[0].with_name(name, lang=lang)
 
 
 class BackendService:

--- a/qiskit_ionq/ionq_result.py
+++ b/qiskit_ionq/ionq_result.py
@@ -80,7 +80,9 @@ class IonQResult(Result):
                         for k, v in header.items()
                         if k in {"time_taken", "creg_sizes", "memory_slots"}
                     }
-                dict_list.append(Counts(self.data(key)["probabilities"], **counts_header))
+                dict_list.append(
+                    Counts(self.data(key)["probabilities"], **counts_header)
+                )
             else:
                 raise exceptions.IonQJobError(
                     f'No probabilities for experiment "{repr(key)}"'

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev2")])
+VERSION_INFO = ".".join([str(x) for x in (0, 3, 1)])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 2, 1, "dev0")])
+VERSION_INFO = ".".join([str(x) for x in (0, 3, 0)])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev1")])
+VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev2")])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 3, 0)])
+VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev0")])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/qiskit_ionq/version.py
+++ b/qiskit_ionq/version.py
@@ -34,7 +34,7 @@ from typing import List
 pkg_parent = pathlib.Path(__file__).parent.parent.absolute()
 
 # major, minor, micro
-VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev0")])
+VERSION_INFO = ".".join([str(x) for x in (0, 3, 0, "dev1")])
 
 
 def _minimal_ext_cmd(cmd: List[str]) -> bytes:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,7 +37,7 @@ from qiskit_ionq.helpers import compress_dict_to_metadata_string
 class MockBackend(ionq_backend.IonQBackend):
     """A mock backend for testing super-class behavior in isolation."""
 
-    def lang(self):
+    def gateset(self):
         return "qis"
 
     def __init__(self, provider, name="ionq_mock_backend"):  # pylint: disable=redefined-outer-name

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,6 +37,9 @@ from qiskit_ionq.helpers import compress_dict_to_metadata_string
 class MockBackend(ionq_backend.IonQBackend):
     """A mock backend for testing super-class behavior in isolation."""
 
+    def lang(self):
+        return "qis"
+
     def __init__(self, provider, name="ionq_mock_backend"):  # pylint: disable=redefined-outer-name
         config = q_models.BackendConfiguration.from_dict(
             {
@@ -63,9 +66,9 @@ class MockBackend(ionq_backend.IonQBackend):
         )
         super().__init__(config, provider=provider)
 
-    def with_name(self, name):
+    def with_name(self, name, **kwargs):
         """Helper method that returns this backend with a more specific target system."""
-        return MockBackend(self._provider, name)
+        return MockBackend(self._provider, name, **kwargs)
 
 def dummy_job_response(job_id, target="mock_backend", status="completed"):
     """A dummy response payload for `job_id`.

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -173,10 +173,11 @@ def test_full_circuit(simulator_backend):
     expected_output_map = [1, 0]
     expected_metadata = {"shots": "200", "sampler_seed": "42"}
     expected_rest_of_payload = {
-        "lang": "qis",
+        "lang": "json",
         "target": "simulator",
         "shots": 200,
         "body": {
+            "gateset": "qis",
             "qubits": 2,
             "circuit": [
                 {"gate": "x", "controls": [1], "targets": [0]},
@@ -206,7 +207,7 @@ def test_circuit_transpile(simulator_backend):
     Args:
         simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
     """
-    new_backend = simulator_backend.with_name("ionq_simulator", lang="native")
+    new_backend = simulator_backend.with_name("ionq_simulator", gateset="native")
     circ = QuantumCircuit(2, 2, name="blame_test")
     circ.cnot(1, 0)
     circ.h(1)
@@ -233,10 +234,10 @@ def test_circuit_incorrect(simulator_backend):
         qiskit_to_ionq(
             circ,
             simulator_backend.name(),
-            lang="native",
+            gateset="native",
             passed_args={"shots": 200, "sampler_seed": 23},
         )
-    assert exc_info.value.lang == "native"
+    assert exc_info.value.gateset == "native"
 
 
 def test_native_circuit_incorrect(simulator_backend):
@@ -252,10 +253,10 @@ def test_native_circuit_incorrect(simulator_backend):
         qiskit_to_ionq(
             circ,
             simulator_backend.name(),
-            lang="qis",
+            gateset="qis",
             passed_args={"shots": 200, "sampler_seed": 23},
         )
-    assert exc_info.value.lang == "qis"
+    assert exc_info.value.gateset == "qis"
     assert exc_info.value.gate_name == "gpi"
 
 
@@ -288,7 +289,7 @@ def test_full_native_circuit(simulator_backend):
     ionq_json = qiskit_to_ionq(
         qc,
         simulator_backend.name(),
-        lang="native",
+        gateset="native",
         passed_args={"shots": 200, "sampler_seed": 23},
     )
     expected_metadata_header = {
@@ -303,10 +304,11 @@ def test_full_native_circuit(simulator_backend):
     }
     expected_metadata = {"shots": "200", "sampler_seed": "23"}
     expected_rest_of_payload = {
-        "lang": "native",
+        "lang": "json",
         "target": "simulator",
         "shots": 200,
         "body": {
+            "gateset": "native",
             "qubits": 3,
             "circuit": [
                 {"gate": "gpi", "target": 0, "phase": 0.1},

--- a/test/helpers/test_qiskit_to_ionq.py
+++ b/test/helpers/test_qiskit_to_ionq.py
@@ -27,10 +27,16 @@
 """Test the qiskit_to_ionq function."""
 
 import json
+import pytest
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.compiler import transpile
+from qiskit.exceptions import QiskitError
+from qiskit.transpiler.exceptions import TranspilerError
 
+from qiskit_ionq.exceptions import IonQGateError
 from qiskit_ionq.helpers import qiskit_to_ionq, decompress_metadata_string_to_dict
+from qiskit_ionq.ionq_gates import GPIGate, GPI2Gate, MSGate
 
 
 def test_output_map__with_multiple_measurements_to_different_clbits(
@@ -77,7 +83,9 @@ def test_output_map__with_multiple_measurements_to_same_clbit(
     assert actual_output_map == [1, None]
 
 
-def test_output_map__with_multiple_registers(simulator_backend):  # pylint: disable=invalid-name
+def test_output_map__with_multiple_registers(
+    simulator_backend,
+):  # pylint: disable=invalid-name
     """Test output map with multiple registers
 
     Args:
@@ -165,7 +173,7 @@ def test_full_circuit(simulator_backend):
     expected_output_map = [1, 0]
     expected_metadata = {"shots": "200", "sampler_seed": "42"}
     expected_rest_of_payload = {
-        "lang": "json",
+        "lang": "qis",
         "target": "simulator",
         "shots": 200,
         "body": {
@@ -189,4 +197,134 @@ def test_full_circuit(simulator_backend):
     assert actual_metadata == expected_metadata
     assert actual_metadata_header == expected_metadata_header
     assert actual_output_map == expected_output_map
+    assert actual == expected_rest_of_payload
+
+
+def test_circuit_transpile(simulator_backend):
+    """Test a full circuit on a native backend via transpilation
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    new_backend = simulator_backend.with_name("ionq_simulator", lang="native")
+    circ = QuantumCircuit(2, 2, name="blame_test")
+    circ.cnot(1, 0)
+    circ.h(1)
+    circ.measure(1, 0)
+    circ.measure(0, 1)
+
+    with pytest.raises(TranspilerError) as exc_info:
+        transpile(circ, backend=new_backend)
+    assert "Unable to map source basis" in exc_info.value.message
+
+
+def test_circuit_incorrect(simulator_backend):
+    """Test a full circuit on a native backend
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    circ = QuantumCircuit(2, 2, name="blame_test")
+    circ.cnot(1, 0)
+    circ.h(1)
+    circ.measure(1, 0)
+    circ.measure(0, 1)
+    with pytest.raises(IonQGateError) as exc_info:
+        qiskit_to_ionq(
+            circ,
+            simulator_backend.name(),
+            lang="native",
+            passed_args={"shots": 200, "sampler_seed": 23},
+        )
+    assert exc_info.value.lang == "native"
+
+
+def test_native_circuit_incorrect(simulator_backend):
+    """Test a full native circuit on a QIS backend
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    circ = QuantumCircuit(3, name="blame_test")
+    circ.append(GPIGate(0.1), [0])
+    circ.append(GPI2Gate(0.2), [1])
+    with pytest.raises(IonQGateError) as exc_info:
+        qiskit_to_ionq(
+            circ,
+            simulator_backend.name(),
+            lang="qis",
+            passed_args={"shots": 200, "sampler_seed": 23},
+        )
+    assert exc_info.value.lang == "qis"
+    assert exc_info.value.gate_name == "gpi"
+
+
+def test_native_circuit_transpile(simulator_backend):
+    """Test a full native circuit on a QIS backend via transpilation
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    circ = QuantumCircuit(3, name="blame_test")
+    circ.append(GPIGate(0.1), [0])
+    circ.append(GPI2Gate(0.2), [1])
+    circ.append(MSGate(0.2, 0.3), [1, 2])
+
+    with pytest.raises(QiskitError) as exc_info:
+        transpile(circ, backend=simulator_backend)
+    assert "Cannot unroll the circuit to the given basis" in exc_info.value.message
+
+
+def test_full_native_circuit(simulator_backend):
+    """Test a full native circuit
+
+    Args:
+        simulator_backend (IonQSimulatorBackend): A simulator backend fixture.
+    """
+    qc = QuantumCircuit(3, name="blame_test")
+    qc.append(GPIGate(0.1), [0])
+    qc.append(GPI2Gate(0.2), [1])
+    qc.append(MSGate(0.2, 0.3), [1, 2])
+    ionq_json = qiskit_to_ionq(
+        qc,
+        simulator_backend.name(),
+        lang="native",
+        passed_args={"shots": 200, "sampler_seed": 23},
+    )
+    expected_metadata_header = {
+        "memory_slots": 0,
+        "global_phase": 0,
+        "n_qubits": 3,
+        "name": "blame_test",
+        "creg_sizes": [],
+        "clbit_labels": [],
+        "qreg_sizes": [["q", 3]],
+        "qubit_labels": [["q", 0], ["q", 1], ["q", 2]],
+    }
+    expected_metadata = {"shots": "200", "sampler_seed": "23"}
+    expected_rest_of_payload = {
+        "lang": "native",
+        "target": "simulator",
+        "shots": 200,
+        "body": {
+            "qubits": 3,
+            "circuit": [
+                {"gate": "gpi", "target": 0, "phase": 0.1},
+                {"gate": "gpi2", "target": 1, "phase": 0.2},
+                {"gate": "ms", "targets": [1, 2], "phases": [0.2, 0.3]},
+            ],
+        },
+    }
+
+    actual = json.loads(ionq_json)
+    actual_metadata = actual.pop("metadata") or {}
+    actual_metadata_header = decompress_metadata_string_to_dict(
+        actual_metadata.pop("qiskit_header") or None
+    )
+    registers = actual.pop("registers") or {}
+
+    # check dict equality:
+    assert actual_metadata == expected_metadata
+    assert actual_metadata_header == expected_metadata_header
+    assert "meas_mapped" not in registers
     assert actual == expected_rest_of_payload

--- a/test/ionq_gates/__init__.py
+++ b/test/ionq_gates/__init__.py
@@ -1,0 +1,25 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -1,0 +1,63 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Copyright 2020 IonQ, Inc. (www.ionq.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the IonQ's GPIGate, GPI2Gate, MSGate."""
+# pylint: disable=redefined-outer-name
+
+import math
+import numpy
+
+import pytest
+
+from qiskit_ionq import GPIGate, GPI2Gate, MSGate
+
+
+@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi/2, math.pi, 2*math.pi])
+def test_gpi_inverse(phase):
+    """Tests that the inverse GPI gate is correct."""
+    gate = GPIGate(phase)
+
+    mat = numpy.array(gate)
+    inv = numpy.array(gate.inverse())
+    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
+
+@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi/2, math.pi, 2*math.pi])
+def test_gpi2_inverse(phase):
+    """Tests that the inverse GPI2 gate is correct."""
+    gate = GPI2Gate(phase)
+
+    mat = numpy.array(gate)
+    inv = numpy.array(gate.inverse())
+    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
+
+@pytest.mark.parametrize("phases", [(0, 1), (0.1, 1), (0.4, 1), (math.pi/2, 0), (0, math.pi), (0.1, 2*math.pi)])
+def test_ms_inverse(phases):
+    """Tests that the inverse MS gate is correct."""
+    gate = MSGate(phases[0], phases[1])
+
+    mat = numpy.array(gate)
+    inv = numpy.array(gate.inverse())
+    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -37,22 +37,20 @@ from qiskit_ionq import GPIGate, GPI2Gate, MSGate
 
 @pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi / 2, math.pi, 2 * math.pi])
 def test_gpi_inverse(phase):
-    """Tests that the inverse GPI gate is correct."""
+    """Tests that the GPI gate is unitary."""
     gate = GPIGate(phase)
 
     mat = numpy.array(gate)
-    inv = numpy.array(gate.inverse())
-    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
+    numpy.testing.assert_array_almost_equal(mat.dot(mat.conj().T), numpy.identity(2))
 
 
 @pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi / 2, math.pi, 2 * math.pi])
 def test_gpi2_inverse(phase):
-    """Tests that the inverse GPI2 gate is correct."""
+    """Tests that the GPI2 gate is unitary."""
     gate = GPI2Gate(phase)
 
     mat = numpy.array(gate)
-    inv = numpy.array(gate.inverse())
-    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
+    numpy.testing.assert_array_almost_equal(mat.dot(mat.conj().T), numpy.identity(2))
 
 
 @pytest.mark.parametrize(
@@ -60,9 +58,8 @@ def test_gpi2_inverse(phase):
     [(0, 1), (0.1, 1), (0.4, 1), (math.pi / 2, 0), (0, math.pi), (0.1, 2 * math.pi)],
 )
 def test_ms_inverse(phases):
-    """Tests that the inverse MS gate is correct."""
+    """Tests that the MS gate is unitary."""
     gate = MSGate(phases[0], phases[1])
 
     mat = numpy.array(gate)
-    inv = numpy.array(gate.inverse())
-    numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
+    numpy.testing.assert_array_almost_equal(mat.dot(mat.conj().T), numpy.identity(4))

--- a/test/ionq_gates/test_gates.py
+++ b/test/ionq_gates/test_gates.py
@@ -35,7 +35,7 @@ import pytest
 from qiskit_ionq import GPIGate, GPI2Gate, MSGate
 
 
-@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi/2, math.pi, 2*math.pi])
+@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi / 2, math.pi, 2 * math.pi])
 def test_gpi_inverse(phase):
     """Tests that the inverse GPI gate is correct."""
     gate = GPIGate(phase)
@@ -44,7 +44,8 @@ def test_gpi_inverse(phase):
     inv = numpy.array(gate.inverse())
     numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
 
-@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi/2, math.pi, 2*math.pi])
+
+@pytest.mark.parametrize("phase", [0, 0.1, 0.4, math.pi / 2, math.pi, 2 * math.pi])
 def test_gpi2_inverse(phase):
     """Tests that the inverse GPI2 gate is correct."""
     gate = GPI2Gate(phase)
@@ -53,7 +54,11 @@ def test_gpi2_inverse(phase):
     inv = numpy.array(gate.inverse())
     numpy.testing.assert_array_almost_equal(inv, numpy.linalg.inv(mat))
 
-@pytest.mark.parametrize("phases", [(0, 1), (0.1, 1), (0.4, 1), (math.pi/2, 0), (0, math.pi), (0.1, 2*math.pi)])
+
+@pytest.mark.parametrize(
+    "phases",
+    [(0, 1), (0.1, 1), (0.4, 1), (math.pi / 2, 0), (0, math.pi), (0.1, 2 * math.pi)],
+)
 def test_ms_inverse(phases):
     """Tests that the inverse MS gate is correct."""
     gate = MSGate(phases[0], phases[1])

--- a/test/ionq_job/test_job.py
+++ b/test/ionq_job/test_job.py
@@ -117,6 +117,22 @@ def test_build_counts():
     assert ({"0x3": 50, "0x7": 50}) == counts
     assert ({"0x3": 0.5, "0x7": 0.5}) == probabilties
 
+def test_build_counts_native():
+    """Test no remapping for native gates."""
+    result = {
+        "qubits": 3,
+        "data": {
+            "histogram": {"5": 0.5, "7": 0.5},
+        },
+        "metadata": {
+            "shots": "100",
+            "qiskit_header": compress_dict_to_metadata_string({"memory_slots": 3}),
+        },
+    }
+    (counts, probabilties) = ionq_job._build_counts(result)
+    assert ({"0x5": 50, "0x7": 50}) == counts
+    assert ({"0x5": 0.5, "0x7": 0.5}) == probabilties
+
 
 def test_results_meta(formatted_result):
     """Test basic job attribute values."""

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -41,8 +41,10 @@ def test_provider_getbackend():
     pro = IonQProvider("123456")
 
     for backend in pro.backends():
-        resolved = pro.get_backend(backend.name())
-        assert backend == resolved
+        qis = pro.get_backend(backend.name())
+        native = pro.get_backend(backend.name(), lang="native")
+        assert backend == qis
+        assert backend != native
 
 
 def test_backend_eq():

--- a/test/ionq_provider/test_backend_service.py
+++ b/test/ionq_provider/test_backend_service.py
@@ -42,7 +42,7 @@ def test_provider_getbackend():
 
     for backend in pro.backends():
         qis = pro.get_backend(backend.name())
-        native = pro.get_backend(backend.name(), lang="native")
+        native = pro.get_backend(backend.name(), gateset="native")
         assert backend == qis
         assert backend != native
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -43,12 +43,12 @@ def test_base_str_and_repr():
 
 def test_gate_error_str_and_repr():
     """Test that IonQAPIError has a str/repr that includes args."""
-    err = exceptions.IonQGateError("a gate", "b lang")
-    str_expected = ("IonQGateError(\"gate 'a gate' is not supported on the 'b lang' IonQ backends."
+    err = exceptions.IonQGateError("a gate", "b set")
+    str_expected = ("IonQGateError(\"gate 'a gate' is not supported on the 'b set' IonQ backends."
                     " Please use the qiskit.transpile method, manually rewrite to remove the gate,"
-                    " or change the language selection as appropriate.\")"
+                    " or change the gateset selection as appropriate.\")"
                    )
-    repr_expected = "IonQGateError(gate_name='a gate', lang='b lang')"
+    repr_expected = "IonQGateError(gate_name='a gate', gateset='b set')"
     assert str(err) == str_expected
     assert repr(err) == repr_expected
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -41,21 +41,14 @@ def test_base_str_and_repr():
     assert repr(err) == repr(expected)
 
 
-def test_gate_error():
-    """Test that IonQAPIError has specific instance attributes."""
-    err = exceptions.IonQGateError("a gate")
-    expected = ("gate 'a gate' not supported on IonQ backends. "
-                "Please use the qiskit.transpile method or manually rewrite to remove the gate")
-    assert err.message == expected
-
-
 def test_gate_error_str_and_repr():
     """Test that IonQAPIError has a str/repr that includes args."""
-    err = exceptions.IonQGateError("a gate")
-    str_expected = ('IonQGateError("gate \'a gate\' not supported on IonQ backends. '
-                   'Please use the qiskit.transpile method or manually rewrite to remove the gate")'
+    err = exceptions.IonQGateError("a gate", "b lang")
+    str_expected = ("IonQGateError(\"gate 'a gate' is not supported on the 'b lang' IonQ backends."
+                    " Please use the qiskit.transpile method, manually rewrite to remove the gate,"
+                    " or change the language selection as appropriate.\")"
                    )
-    repr_expected = "IonQGateError(gate_name='a gate')"
+    repr_expected = "IonQGateError(gate_name='a gate', lang='b lang')"
     assert str(err) == str_expected
     assert repr(err) == repr_expected
 


### PR DESCRIPTION
IonQ Native gates support in Qiskit

Bump to 0.3.0

### Summary

This PR allows configuration of a 'lang' when creating an IonQBackend, which controls the basis gates used. "qis" is the existing default, and "native" allows for programming with GPI, GPI2 and MS gates.

These gates are also defined in this PR, along with matrix representations

### Details and comments
