### PR TITLE
Fix calibration() method

### DIFF
--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -347,7 +347,7 @@ class IonQSimulatorBackend(IonQBackend):
                 "description": "IonQ simulator",
                 "basis_gates": GATESET_MAP[gateset],
                 "memory": False,
-                "n_qubits": 32,
+                "n_qubits": 32, # Varied based on noise model, but enforced server-side.
                 "conditional": False,
                 "max_shots": 1,
                 "max_experiments": 1,

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -51,7 +51,7 @@ class Calibration:
         self._data = data
 
     @property
-    def id(self):
+    def uuid(self):
         """The ID of the calibration.
 
         Returns:

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -27,7 +27,7 @@
 """IonQ provider backends."""
 
 import abc
-import datetime
+from datetime import datetime
 import warnings
 
 import dateutil.parser

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -27,6 +27,7 @@
 """IonQ provider backends."""
 
 import abc
+import datetime
 import warnings
 
 import dateutil.parser
@@ -50,6 +51,15 @@ class Calibration:
         self._data = data
 
     @property
+    def id(self):
+        """The ID of the calibration.
+
+        Returns:
+           str: The ID.
+        """
+        return self._data["id"]
+
+    @property
     def num_qubits(self):
         """The number of qubits available.
 
@@ -65,7 +75,7 @@ class Calibration:
         Returns:
             str: The name of the target hardware backend.
         """
-        return self._data["target"]
+        return self._data["backend"]
 
     @property
     def calibration_time(self):
@@ -74,7 +84,7 @@ class Calibration:
         Returns:
             datetime.datetime: A datetime object with the time.
         """
-        return dateutil.parser.isoparse(self._data["date"])
+        return datetime.fromtimestamp(self._data["date"])
 
     @property
     def fidelities(self):

--- a/qiskit_ionq/ionq_backend.py
+++ b/qiskit_ionq/ionq_backend.py
@@ -30,7 +30,6 @@ import abc
 from datetime import datetime
 import warnings
 
-import dateutil.parser
 from qiskit.providers import BackendV1 as Backend
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers.models.backendstatus import BackendStatus

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -167,17 +167,18 @@ class IonQClient:
         Calibration::
 
             {
+                "id": <str>,
                 "calibration_time": <int>,
                 "target": <str>,
                 "num_qubits": <int>,
                 "connectivity": [<int>, ...],
-                "fidelities": {
+                "fidelity": {
                     "spam": {
                         "mean": <int>,
                         "stderr": <int>
                     }
                 },
-                "timings": {
+                "timing": {
                     "readout": <int>,
                     "reset": <int>
                 }
@@ -186,31 +187,8 @@ class IonQClient:
         Returns:
             dict: A dictionary of an IonQ backend's calibration data.
         """
-        req_path = self.make_path("backends")
+        req_path = self.make_path("/".join(["characterizations/backends", backend_name[5:], "current"]))
         res = requests.get(req_path, headers=self.api_headers, timeout=30)
-        exceptions.IonQAPIError.raise_for_status(res)
-
-        # Get calibrations and filter down to the target
-        response = res.json()
-        warnings.warn(f"{response}")
-        backend = [b for b in response if backend_name.endswith(b.get("backend")) ]
-
-        # If nothing was found, just return None.
-        if len(backend) == 0:
-            warnings.warn(f"Backend {backend_name} not found")
-            return None
-
-        if len(backend) > 1:
-            warnings.warn(f"Backend {backend_name} matches multiple, using the first found")
-            return None
-
-        characterization_url = backend[0].get("characterization_url")
-        if len(characterization_url) == 0:
-            warnings.warn(f"Backend {backend} did not have calibration data")
-            return None
-
-        full_url = self.make_path(characterization_url[1:])
-        res = requests.get(full_url, headers=self.api_headers, timeout=30)
         exceptions.IonQAPIError.raise_for_status(res)
 
         return res.json()

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -167,26 +167,21 @@ class IonQClient:
         Calibration::
 
             {
-                "pages": <int>,
-                "calibrations": [
-                    {
-                        "id": <str>,
-                        "date": <int>,
-                        "target": <str>,
-                        "qubits": <int>,
-                        "connectivity": [<int>, ...],
-                        "fidelity": {
-                            "spam": {
-                                "mean": <int>,
-                                "stderr": <int>
-                            }
-                        },
-                        "timing": {
-                            "readout": <int>,
-                            "reset": <int>
-                        }
+                "id": <str>,
+                "date": <int>,
+                "target": <str>,
+                "qubits": <int>,
+                "connectivity": [<int>, ...],
+                "fidelity": {
+                    "spam": {
+                        "mean": <int>,
+                        "stderr": <int>
                     }
-                ]
+                },
+                "timing": {
+                    "readout": <int>,
+                    "reset": <int>
+                }
             }
 
         Returns:

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -26,7 +26,6 @@
 
 """Basic API Client for IonQ's REST API"""
 
-import warnings
 import requests
 
 from retry import retry
@@ -187,7 +186,11 @@ class IonQClient:
         Returns:
             dict: A dictionary of an IonQ backend's calibration data.
         """
-        req_path = self.make_path("/".join(["characterizations/backends", backend_name[5:], "current"]))
+        req_path = self.make_path("/".join([
+            "characterizations/backends",
+            backend_name[5:],
+            "current"
+        ]))
         res = requests.get(req_path, headers=self.api_headers, timeout=30)
         exceptions.IonQAPIError.raise_for_status(res)
 

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -26,8 +26,8 @@
 
 """Basic API Client for IonQ's REST API"""
 
-import requests
 import warnings
+import requests
 
 from retry import retry
 

--- a/qiskit_ionq/ionq_client.py
+++ b/qiskit_ionq/ionq_client.py
@@ -167,18 +167,17 @@ class IonQClient:
         Calibration::
 
             {
-                "id": <str>,
-                "date": <int>,
+                "calibration_time": <int>,
                 "target": <str>,
-                "qubits": <int>,
+                "num_qubits": <int>,
                 "connectivity": [<int>, ...],
-                "fidelity": {
+                "fidelities": {
                     "spam": {
                         "mean": <int>,
                         "stderr": <int>
                     }
                 },
-                "timing": {
+                "timings": {
                     "readout": <int>,
                     "reset": <int>
                 }

--- a/qiskit_ionq/ionq_provider.py
+++ b/qiskit_ionq/ionq_provider.py
@@ -44,7 +44,7 @@ def resolve_credentials(token: str = None, url: str = None):
     are loaded from the ``QISKIT_IONQ_API_TOKEN`` and ``QISKIT_IONQ_API_URL``
     environment variables, respectively.
 
-    If no url is discovered, then ``https://api.ionq.co/v0.1`` is used.
+    If no url is discovered, then ``https://api.ionq.co/v0.2`` is used.
 
     Args:
         token (str): IonQ API access token.
@@ -57,7 +57,7 @@ def resolve_credentials(token: str = None, url: str = None):
     env_url = os.environ.get("QISKIT_IONQ_API_URL")
     return {
         "token": token or env_token,
-        "url": url or env_url or "https://api.ionq.co/v0.1",
+        "url": url or env_url or "https://api.ionq.co/v0.2",
     }
 
 


### PR DESCRIPTION
Also update to use the v0.2 base URL

There were a few issues with calibration(), mainly:

1. list calibrations endpoint no longer exists
2. code that was ported to raise_for_status was ported incorrectly, doubly breaking it (mea culpa on this one, I think)

This was tested manually, we'll have to add this to our internal integration testing to avoid this kind of breakage, which I can do as a followup
