### PR TITLE
_RETRIABLE_STATUS_CODES += bad_gateway

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -94,13 +94,14 @@ class IonQAPIError(IonQError):
             response (:class:`Response <requests.Response>`): An IonQ REST API response.
 
         Raises:
-            IonQAPIError: instance of `cls` with error detail from `response`."""
+            IonQAPIError: instance of `cls` with error detail from `response`.
+            IonQRetriableError:  instance of `cls` with error detail from `response`."""
         status_code = response.status_code
         if status_code == 200:
             return None
         res = cls.from_response(response)
         if _is_retriable(response.request.method, status_code):
-          raise IonQRetriableError(res)
+            raise IonQRetriableError(res)
         raise res
 
 

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -71,6 +71,7 @@ _RETRIABLE_FOR_GETS = {requests.codes.conflict}
 # See https://support.cloudflare.com/hc/en-us/articles/115003011431/
 _RETRIABLE_STATUS_CODES = {
     requests.codes.internal_server_error,
+    requests.codes.bad_gateway,
     requests.codes.service_unavailable,
     *list(range(520, 530)),
 }

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -99,9 +99,9 @@ class IonQAPIError(IonQError):
         if status_code == 200:
             return None
         res = cls.from_response(response)
-        raise (IonQRetriableError(res)
-                if _is_retriable(response.request.method, status_code)
-                else res)
+        if _is_retriable(response.request.method, status_code):  
+          raise IonQRetriableError(res)
+        raise res
 
 
     @classmethod

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -99,7 +99,7 @@ class IonQAPIError(IonQError):
         if status_code == 200:
             return None
         res = cls.from_response(response)
-        if _is_retriable(response.request.method, status_code):  
+        if _is_retriable(response.request.method, status_code):
           raise IonQRetriableError(res)
         raise res
 


### PR DESCRIPTION
bad_gateway (502 response status) has been seen in production causing issues retrieving job results in scripts because the error is not retried.

502 should be safe to retry similarly to other 5xx responses (though we will need to make sure these retries do not cause duplicate submission API-side, time to start writing [etags](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)?)