### PR TITLE
Persists Qiskit QuantumCircuit name to IonQ Backend

### DIFF
--- a/qiskit_ionq/helpers.py
+++ b/qiskit_ionq/helpers.py
@@ -229,7 +229,8 @@ def qiskit_circ_to_ionq_circ(input_circuit, gateset="qis"):
                     for i in range(instruction.num_ctrl_qubits)
                 ]
                 targets = [
-                    input_circuit.qubits.index(qargs[instruction.num_ctrl_qubits])
+                    input_circuit.qubits.index(
+                        qargs[instruction.num_ctrl_qubits])
                 ]
             if gate == "swap":
                 # If this is a cswap, we have two targets:
@@ -353,7 +354,8 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
         str: A string / JSON-serialized dictionary with IonQ API compatible values.
     """
     passed_args = passed_args or {}
-    ionq_circ, _, meas_map = qiskit_circ_to_ionq_circ(circuit, backend.gateset())
+    ionq_circ, _, meas_map = qiskit_circ_to_ionq_circ(
+        circuit, backend.gateset())
     creg_sizes, clbit_labels = get_register_sizes_and_labels(circuit.cregs)
     qreg_sizes, qubit_labels = get_register_sizes_and_labels(circuit.qregs)
     qiskit_header = compress_dict_to_metadata_string(
@@ -362,10 +364,14 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
             "global_phase": circuit.global_phase,  # float
             "n_qubits": circuit.num_qubits,  # int
             "name": circuit.name,  # str
-            "creg_sizes": creg_sizes,  # list of [str, int] tuples cardinality memory_slots
-            "clbit_labels": clbit_labels,  # list of [str, int] tuples cardinality memory_slots
-            "qreg_sizes": qreg_sizes,  # list of [str, int] tuples cardinality num_qubits
-            "qubit_labels": qubit_labels,  # list of [str, int] tuples cardinality num_qubits
+            # list of [str, int] tuples cardinality memory_slots
+            "creg_sizes": creg_sizes,
+            # list of [str, int] tuples cardinality memory_slots
+            "clbit_labels": clbit_labels,
+            # list of [str, int] tuples cardinality num_qubits
+            "qreg_sizes": qreg_sizes,
+            # list of [str, int] tuples cardinality num_qubits
+            "qubit_labels": qubit_labels,
         }
     )
 
@@ -374,6 +380,7 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
         "lang": "json",
         "target": target,
         "shots": passed_args.get("shots"),
+        "name": circuit.name,
         "body": {
             "gateset": backend.gateset(),
             "qubits": circuit.num_qubits,
@@ -389,8 +396,8 @@ def qiskit_to_ionq(circuit, backend, passed_args=None):
     }
     if target == "simulator":
         ionq_json["noise"] = {
-                "model": backend.options.noise_model,
-                "seed": backend.options.sampler_seed,
+            "model": backend.options.noise_model,
+            "seed": backend.options.sampler_seed,
         }
     settings = passed_args.get("job_settings") or None
     if settings is not None:


### PR DESCRIPTION
<!--
✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Adds `circuit.name` to `ionq_json` object.

### Details and comments

This propagates the circuit name to the cloud.ionq.com dashboard.