### PR TITLE
Include full http response on exception

### DIFF
--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -122,7 +122,8 @@ class IonQAPIError(IonQError):
         """
         # TODO: Pending API changes will cleanup this error logic:
         status_code = response.status_code
-        http_response = response.reason
+        headers = response.headers
+        body = response.text
         try:
             response_json = response.json()
         except jd.JSONDecodeError:
@@ -142,20 +143,22 @@ class IonQAPIError(IonQError):
             error_data = response_json.get("error")
             message = error_data.get("message") or message
             error_type = error_data.get("type") or error_type
-        return cls(message, http_response, status_code, error_type)
+        return cls(message, status_code, headers, body, error_type)
 
-    def __init__(self, message, http_response, status_code, error_type):
-        self.status_code = status_code
-        self.http_response = http_response
-        self.error_type = error_type
+    def __init__(self, message, status_code, headers, body, error_type):
         super().__init__(message)
+        self.status_code = status_code
+        self.headers = headers
+        self.body = body
+        self.error_type = error_type
 
     def __str__(self):
         return (
             f"{self.__class__.__name__}("
             f"message={self.message!r},"
-            f"http_response={self.http_response!r},"
-            f"status_code={self.status_code},"
+            f"status_code={self.status_code!r},"
+            f"headers={self.headers},"
+            f"body={self.body},"
             f"error_type={self.error_type!r})"
         )
 

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -52,6 +52,7 @@ class IonQCredentialsError(IonQError):
 class IonQClientError(IonQError):
     """Errors that arise from unexpected behavior while using IonQClient."""
 
+
 class IonQRetriableError(IonQError):
     """Errors that do not indicate a failure related to the request, and can be retried."""
 
@@ -60,6 +61,7 @@ class IonQRetriableError(IonQError):
         super().__init__(cause.message)
 
 # pylint: disable=no-member
+
 
 # https://support.cloudflare.com/hc/en-us/articles/115003014512-4xx-Client-Error
 # "Cloudflare will generate and serve a 409 response for a Error 1001: DNS Resolution Error."
@@ -76,8 +78,11 @@ _RETRIABLE_STATUS_CODES = {
     *list(range(520, 530)),
 }
 # pylint: enable=no-member
+
+
 def _is_retriable(method, code):
     return code in _RETRIABLE_STATUS_CODES or (method == "GET" and code in _RETRIABLE_FOR_GETS)
+
 
 class IonQAPIError(IonQError):
     """Base exception for fatal API errors.
@@ -104,7 +109,6 @@ class IonQAPIError(IonQError):
             raise IonQRetriableError(res)
         raise res
 
-
     @classmethod
     def from_response(cls, response):
         """Raise an instance of the exception class from an API response object.
@@ -118,10 +122,11 @@ class IonQAPIError(IonQError):
         """
         # TODO: Pending API changes will cleanup this error logic:
         status_code = response.status_code
+        url = response.url
         try:
             response_json = response.json()
         except jd.JSONDecodeError:
-            response_json = { 'invalid_json': response.text }
+            response_json = {'invalid_json': response.text}
         # Defaults, if items cannot be extracted from the response.
         error_type = "internal_error"
         message = "No error details provided."
@@ -137,6 +142,7 @@ class IonQAPIError(IonQError):
             error_data = response_json.get("error")
             message = error_data.get("message") or message
             error_type = error_data.get("type") or error_type
+        message += f" {url}"
         return cls(message, status_code, error_type)
 
     def __init__(self, message, status_code, error_type):
@@ -181,9 +187,9 @@ class IonQGateError(IonQError, JobError):
         self.gateset = gateset
         super().__init__(
             (f"gate '{gate_name}' is not supported on the '{gateset}' IonQ backends. "
-              "Please use the qiskit.transpile method, manually rewrite to remove the gate, "
-              "or change the gateset selection as appropriate."
-            )
+             "Please use the qiskit.transpile method, manually rewrite to remove the gate, "
+             "or change the gateset selection as appropriate."
+             )
         )
 
     def __repr__(self):

--- a/qiskit_ionq/exceptions.py
+++ b/qiskit_ionq/exceptions.py
@@ -122,7 +122,7 @@ class IonQAPIError(IonQError):
         """
         # TODO: Pending API changes will cleanup this error logic:
         status_code = response.status_code
-        url = response.url
+        http_response = response.reason
         try:
             response_json = response.json()
         except jd.JSONDecodeError:
@@ -142,11 +142,11 @@ class IonQAPIError(IonQError):
             error_data = response_json.get("error")
             message = error_data.get("message") or message
             error_type = error_data.get("type") or error_type
-        message += f" {url}"
-        return cls(message, status_code, error_type)
+        return cls(message, http_response, status_code, error_type)
 
-    def __init__(self, message, status_code, error_type):
+    def __init__(self, message, http_response, status_code, error_type):
         self.status_code = status_code
+        self.http_response = http_response
         self.error_type = error_type
         super().__init__(message)
 
@@ -154,6 +154,7 @@ class IonQAPIError(IonQError):
         return (
             f"{self.__class__.__name__}("
             f"message={self.message!r},"
+            f"http_response={self.http_response!r},"
             f"status_code={self.status_code},"
             f"error_type={self.error_type!r})"
         )

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -26,6 +26,7 @@
 
 """Test basic exceptions behavior"""
 
+import requests
 from unittest import mock
 
 import pytest
@@ -57,19 +58,32 @@ def test_gate_error_str_and_repr():
 def test_api_error():
     """Test that IonQAPIError has specific instance attributes."""
     err = exceptions.IonQAPIError(
-        "an error", "http response", 500, "internal_error")
+        message="an error",
+        status_code=500,
+        headers={"Content-Type": "text/html"},
+        body="<!doctype html><html><body>Hello IonQ!</body></html>",
+        error_type="internal_error"
+    )
     assert err.message == "an error"
     assert err.status_code == 500
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_api_error_str_and_repr():
     """Test that IonQAPIError has a str/repr that includes args."""
     err = exceptions.IonQAPIError(
-        "an error", "http response", 500, "internal_error")
+        message="an error",
+        status_code=500,
+        headers={"Content-Type": "text/html"},
+        body="<!doctype html><html><body>Hello IonQ!</body></html>",
+        error_type="internal_error"
+    )
     expected = ("IonQAPIError(message='an error',"
-                "http_response='http response',"
                 "status_code=500,"
+                "headers={'Content-Type': 'text/html'},"
+                "body=<!doctype html><html><body>Hello IonQ!</body></html>,"
                 "error_type='internal_error')")
     assert str(err) == expected
     assert repr(err) == repr(expected)
@@ -77,80 +91,108 @@ def test_api_error_str_and_repr():
 
 def test_api_error_from_response():
     """Test that IonQAPIError can be made directly from a response JSON dict."""
-    fake_response = mock.MagicMock()
-    fake_response.json = mock.MagicMock(
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "error": {
-                "type": "internal_error",
                 "message": "an error",
+                "type": "internal_error",
             }
         }
     )
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        raise exceptions.IonQAPIError.from_response(fake_response)
+        raise exceptions.IonQAPIError.from_response(response)
 
     err = exc.value
     assert err.message == "an error"
     assert err.status_code == 500
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_api_error_raise_for_status():
     """Test that IonQAPIError can be made directly from a response JSON dict."""
-    fake_response = mock.MagicMock()
-    fake_response.json = mock.MagicMock(
+    # Create a request object
+    request = requests.Request('POST', 'https://api.ionq.co')
+    prepared_request = request.prepare()
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Set the request attribute of the response object
+    response.request = prepared_request
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "error": {
-                "type": "internal_error",
                 "message": "an error",
+                "type": "internal_error",
             }
         }
     )
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
 
     with pytest.raises(exceptions.IonQRetriableError) as exc:
-        exceptions.IonQAPIError.raise_for_status(fake_response)
+        exceptions.IonQAPIError.raise_for_status(response)
 
     err = exc.value._cause
     assert err.message == "an error"
     assert err.status_code == 500
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_retriable_raise_for_status():
     """Test that IonQAPIError can be made directly from a response JSON dict."""
-    fake_response = mock.MagicMock()
-    fake_response.json = mock.MagicMock(
+    # Create a request object
+    request = requests.Request('POST', 'https://api.ionq.co')
+    prepared_request = request.prepare()
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 400
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Set the request attribute of the response object
+    response.request = prepared_request
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "error": {
-                "type": "invalid_request",
                 "message": "an error",
+                "type": "invalid_request",
             }
         }
     )
-    fake_response.status_code = 400
-    fake_response.reason = "http failure response"
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        exceptions.IonQAPIError.raise_for_status(fake_response)
+        exceptions.IonQAPIError.raise_for_status(response)
 
     err = exc.value
     assert err.message == "an error"
     assert err.status_code == 400
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "invalid_request"
     assert err is not IonQRetriableError
 
 
 def test_error_format__code_message():
     """Test the {"code": <int>, "message": <str>} error response format."""
-    fake_response = mock.MagicMock()
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
-    fake_response.json = mock.MagicMock(
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "code": 500,
             "message": "an error",
@@ -158,20 +200,25 @@ def test_error_format__code_message():
     )
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        raise exceptions.IonQAPIError.from_response(fake_response)
+        raise exceptions.IonQAPIError.from_response(response)
 
     err = exc.value
     assert err.status_code == 500
     assert err.message == "an error"
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_error_format_bad_request():
     """Test the { "statusCode": <int>, "error": <str>, "message": <str> } error response format."""
-    fake_response = mock.MagicMock()
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
-    fake_response.json = mock.MagicMock(
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "statusCode": 500,
             "error": "internal_error",
@@ -180,20 +227,25 @@ def test_error_format_bad_request():
     )
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        raise exceptions.IonQAPIError.from_response(fake_response)
+        raise exceptions.IonQAPIError.from_response(response)
 
     err = exc.value
     assert err.status_code == 500
     assert err.message == "an error"
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_error_format__nested_error():
     """Test the { "error": { "type": <str>, "message: <str> } } error response format."""
-    fake_response = mock.MagicMock()
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
-    fake_response.json = mock.MagicMock(
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(
         return_value={
             "error": {
                 "message": "an error",
@@ -203,25 +255,32 @@ def test_error_format__nested_error():
     )
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        raise exceptions.IonQAPIError.from_response(fake_response)
+        raise exceptions.IonQAPIError.from_response(response)
 
     err = exc.value
     assert err.status_code == 500
     assert err.message == "an error"
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"
 
 
 def test_error_format__default():
     """Test the when no known error format comes back."""
-    fake_response = mock.MagicMock()
-    fake_response.status_code = 500
-    fake_response.reason = "http failure response"
-    fake_response.json = mock.MagicMock(return_value={})
+    # Create a response object
+    response = requests.Response()
+    response.status_code = 500
+    response.headers = {"Content-Type": "text/html"}
+    response._content = b"<!doctype html><html><body>Hello IonQ!</body></html>"
+    # Mock the json method of the response object
+    response.json = mock.MagicMock(return_value={})
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
-        raise exceptions.IonQAPIError.from_response(fake_response)
+        raise exceptions.IonQAPIError.from_response(response)
 
     err = exc.value
     assert err.status_code == 500
     assert err.message == "No error details provided."
+    assert err.headers == {"Content-Type": "text/html"}
+    assert err.body == "<!doctype html><html><body>Hello IonQ!</body></html>"
     assert err.error_type == "internal_error"

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -26,8 +26,8 @@
 
 """Test basic exceptions behavior"""
 
-import requests
 from unittest import mock
+import requests
 
 import pytest
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -33,6 +33,7 @@ import pytest
 from qiskit_ionq import exceptions
 from qiskit_ionq.exceptions import IonQRetriableError
 
+
 def test_base_str_and_repr():
     """Test basic str and repr support."""
     err = exceptions.IonQError()
@@ -47,7 +48,7 @@ def test_gate_error_str_and_repr():
     str_expected = ("IonQGateError(\"gate 'a gate' is not supported on the 'b set' IonQ backends."
                     " Please use the qiskit.transpile method, manually rewrite to remove the gate,"
                     " or change the gateset selection as appropriate.\")"
-                   )
+                    )
     repr_expected = "IonQGateError(gate_name='a gate', gateset='b set')"
     assert str(err) == str_expected
     assert repr(err) == repr_expected
@@ -55,16 +56,18 @@ def test_gate_error_str_and_repr():
 
 def test_api_error():
     """Test that IonQAPIError has specific instance attributes."""
-    err = exceptions.IonQAPIError("an error", 500, "internal_error")
-    assert err.message == "an error"
+    err = exceptions.IonQAPIError(
+        "an error https://api.ionq.co/", 500, "internal_error")
+    assert err.message == "an error https://api.ionq.co/"
     assert err.status_code == 500
     assert err.error_type == "internal_error"
 
 
 def test_api_error_str_and_repr():
     """Test that IonQAPIError has a str/repr that includes args."""
-    err = exceptions.IonQAPIError("an error", 500, "internal_error")
-    expected = "IonQAPIError(message='an error',status_code=500,error_type='internal_error')"
+    err = exceptions.IonQAPIError(
+        "an error https://api.ionq.co/", 500, "internal_error")
+    expected = "IonQAPIError(message='an error https://api.ionq.co/',status_code=500,error_type='internal_error')"
     assert str(err) == expected
     assert repr(err) == repr(expected)
 
@@ -81,14 +84,16 @@ def test_api_error_from_response():
         }
     )
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
         raise exceptions.IonQAPIError.from_response(fake_response)
 
     err = exc.value
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.status_code == 500
     assert err.error_type == "internal_error"
+
 
 def test_api_error_raise_for_status():
     """Test that IonQAPIError can be made directly from a response JSON dict."""
@@ -102,14 +107,16 @@ def test_api_error_raise_for_status():
         }
     )
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
 
     with pytest.raises(exceptions.IonQRetriableError) as exc:
         exceptions.IonQAPIError.raise_for_status(fake_response)
 
     err = exc.value._cause
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.status_code == 500
     assert err.error_type == "internal_error"
+
 
 def test_retriable_raise_for_status():
     """Test that IonQAPIError can be made directly from a response JSON dict."""
@@ -123,12 +130,13 @@ def test_retriable_raise_for_status():
         }
     )
     fake_response.status_code = 400
+    fake_response.url = "https://api.ionq.co/"
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
         exceptions.IonQAPIError.raise_for_status(fake_response)
 
     err = exc.value
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.status_code == 400
     assert err.error_type == "invalid_request"
     assert err is not IonQRetriableError
@@ -138,6 +146,7 @@ def test_error_format__code_message():
     """Test the {"code": <int>, "message": <str>} error response format."""
     fake_response = mock.MagicMock()
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
     fake_response.json = mock.MagicMock(
         return_value={
             "code": 500,
@@ -150,7 +159,7 @@ def test_error_format__code_message():
 
     err = exc.value
     assert err.status_code == 500
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.error_type == "internal_error"
 
 
@@ -158,6 +167,7 @@ def test_error_format_bad_request():
     """Test the { "statusCode": <int>, "error": <str>, "message": <str> } error response format."""
     fake_response = mock.MagicMock()
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
     fake_response.json = mock.MagicMock(
         return_value={
             "statusCode": 500,
@@ -171,7 +181,7 @@ def test_error_format_bad_request():
 
     err = exc.value
     assert err.status_code == 500
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.error_type == "internal_error"
 
 
@@ -179,6 +189,7 @@ def test_error_format__nested_error():
     """Test the { "error": { "type": <str>, "message: <str> } } error response format."""
     fake_response = mock.MagicMock()
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
     fake_response.json = mock.MagicMock(
         return_value={
             "error": {
@@ -193,7 +204,7 @@ def test_error_format__nested_error():
 
     err = exc.value
     assert err.status_code == 500
-    assert err.message == "an error"
+    assert err.message == "an error https://api.ionq.co/"
     assert err.error_type == "internal_error"
 
 
@@ -201,6 +212,7 @@ def test_error_format__default():
     """Test the when no known error format comes back."""
     fake_response = mock.MagicMock()
     fake_response.status_code = 500
+    fake_response.url = "https://api.ionq.co/"
     fake_response.json = mock.MagicMock(return_value={})
 
     with pytest.raises(exceptions.IonQAPIError) as exc:
@@ -208,5 +220,5 @@ def test_error_format__default():
 
     err = exc.value
     assert err.status_code == 500
-    assert err.message == "No error details provided."
+    assert err.message == "No error details provided. https://api.ionq.co/"
     assert err.error_type == "internal_error"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short, detailed and understandable for all.
⚠️ If your pull request addresses an open issue, please link to the issue.

✅ I have added tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

😊 Thank you for helping make this project better!
-->

### Summary

Includes full http response in expections

### Details and comments

includes this `http_response` [alongside](https://github.com/Qiskit-Partners/qiskit-ionq/blob/c757237c76bacf31ebf3391f7dd1ee86c57c5b23/qiskit_ionq/exceptions.py#L157-L159) `error_type`. alternatively we can just show the `http_response`.

