### PR TITLE
deploy documentation in qiskit.org/ecosystem

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -3,7 +3,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2021.
+# (C) Copyright IBM 2017, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Script for pushing the documentation to the qiskit.org repository.
+# Script for pushing the documentation to qiskit.org/ecosystem
 set -e
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
@@ -27,7 +27,8 @@ tox -edocs
 echo "show current dir: "
 pwd
 
-# Push to qiskit.org website
+# Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
-echo "Pushing built docs to website"
+echo "Pushing built docs to qiskti.org/ecosystem"
 rclone sync --progress ./build/html IBMCOS:qiskit-org-web-resources/documentation/partners/ionq
+rclone sync --progress ./build/html IBMCOS:qiskit-org-web-resources/ecosystem/ionq


### PR DESCRIPTION
Similar to https://github.com/Qiskit/qiskit-aer/pull/1748, see https://github.com/Qiskit/qiskit.org/issues/3038 for more context

### Summary

The Qiskit Ecosystem lives in qiskit.org/ecosystem and new place for qiskit related projects that are not technically Qiskit. This PR adds that destination for documentation deployment.

### Details and comments

For now, a copy of the same docs in ecosystem would allow to have both q.o/documentation and q.o/ecosystem for testing that everything is fine. Once that's done, the CDN will redirects to the new location and the deploy to q.o/documentation can be removed.